### PR TITLE
update code model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,13 @@ list-gitleaks:
 		-d '{"project_id":1, "code_data_source_id":1001, "gitleaks_id":1}' \
 		localhost:8081 datasource.code.CodeService.ListGitleaks
 
+.PHONY: get-gitleaks
+get-gitleaks:
+	grpcurl \
+		-plaintext \
+		-d '{"project_id":1, "gitleaks_id":1}' \
+		localhost:8081 datasource.code.CodeService.GetGitleaks
+
 .PHONY: put-gitleaks
 put-gitleaks:
 	grpcurl \

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ca-risken/datasource-api
 go 1.17
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/aws/aws-sdk-go v1.44.27
 	github.com/ca-risken/common/pkg/database v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b
@@ -10,7 +11,6 @@ require (
 	github.com/ca-risken/common/pkg/rpc v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/core/proto/project v0.0.0-20220428031553-0579e204c316
-	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
@@ -22,6 +22,7 @@ require (
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/DataDog/dd-trace-go.v1 v1.38.1
+	gorm.io/driver/mysql v1.1.1
 	gorm.io/gorm v1.22.3
 )
 
@@ -38,6 +39,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
@@ -65,5 +67,4 @@ require (
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	gorm.io/driver/mysql v1.1.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583 h1:3nVO1nQyh64IUY6BPZUpMYMZ738Pu+LsMt3E0eqqIYw=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583/go.mod h1:EP9f4GqaDJyP1F5jTNMtzdIpw3JpNs3rMSJOnYywCiw=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -166,7 +166,7 @@ func (c *Client) DeleteGitHubSetting(ctx context.Context, projectID uint32, gith
 }
 
 func (c *Client) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error) {
-	query := `select * from code_gitleaks_setting where and project_id = ?`
+	query := `select * from code_gitleaks_setting where project_id = ?`
 	var params []interface{}
 	params = append(params, projectID)
 	data := []model.CodeGitleaksSetting{}

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -14,16 +14,22 @@ type CodeRepoInterface interface {
 	// code_data_source
 	ListCodeDataSource(ctx context.Context, codeDataSourceID uint32, name string) (*[]model.CodeDataSource, error)
 
-	// code_gitleaks
-	ListGitleaks(ctx context.Context, projectID, codeDataSourceID, gitleaksID uint32) (*[]model.CodeGitleaks, error)
-	UpsertGitleaks(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaks, error)
-	DeleteGitleaks(ctx context.Context, projectID uint32, gitleaksID uint32) error
-	GetGitleaks(ctx context.Context, projectID, gitleaksID uint32) (*model.CodeGitleaks, error)
+	// code_github_setting
+	ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error)
+	GetGithubSetting(ctx context.Context, projectID, GithubSettingID uint32) (*model.CodeGithubSetting, error)
+	UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error)
+	DeleteGithubSetting(ctx context.Context, projectID uint32, GithubSettingID uint32) error
 
-	// code_enterprise_org
-	ListEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32) (*[]model.CodeEnterpriseOrg, error)
-	UpsertEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeEnterpriseOrg, error)
-	DeleteEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32, login string) error
+	// code_gitleaks_setting
+	ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error)
+	GetGitleaksSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGitleaksSetting, error)
+	UpsertGitleaksSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaksSetting, error)
+	DeleteGitleaksSetting(ctx context.Context, projectID uint32, GithubSettingID uint32) error
+
+	// code_github_enterprise_org
+	ListGithubEnterpriseOrg(ctx context.Context, projectID, GithubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error)
+	UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error)
+	DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error
 }
 
 var _ CodeRepoInterface = (*Client)(nil) // verify interface compliance
@@ -46,247 +52,241 @@ func (c *Client) ListCodeDataSource(ctx context.Context, codeDataSourceID uint32
 	return &data, nil
 }
 
-func (c *Client) ListGitleaks(ctx context.Context, projectID, codeDataSourceID, gitleaksID uint32) (*[]model.CodeGitleaks, error) {
-	query := `select * from code_gitleaks where 1=1`
+func (c *Client) ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error) {
+	query := `select * from code_github_setting where 1=1`
 	var params []interface{}
 	if !zero.IsZeroVal(projectID) {
 		query += " and project_id = ?"
 		params = append(params, projectID)
 	}
-	if !zero.IsZeroVal(codeDataSourceID) {
-		query += " and code_data_source_id = ?"
-		params = append(params, codeDataSourceID)
+	if !zero.IsZeroVal(githubSettingID) {
+		query += " and code_github_setting_id = ?"
+		params = append(params, githubSettingID)
 	}
-	if !zero.IsZeroVal(gitleaksID) {
-		query += " and gitleaks_id = ?"
-		params = append(params, gitleaksID)
-	}
-	data := []model.CodeGitleaks{}
+	data := []model.CodeGithubSetting{}
 	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) UpsertGitleaks(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaks, error) {
+func (c *Client) GetGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*model.CodeGithubSetting, error) {
+	var data model.CodeGithubSetting
+	if err := c.SlaveDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&data).Error; err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+func (c *Client) UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
 	if data.PersonalAccessToken != "" {
-		return c.UpsertGitleaksWithToken(ctx, data)
+		return c.UpsertGithubSettingWithToken(ctx, data)
 	}
-	return c.UpsertGitleaksWithoutToken(ctx, data)
+	return c.UpsertGithubSettingWithoutToken(ctx, data)
 }
 
-const insertUpsertGitleaksWithToken = `
-INSERT INTO code_gitleaks (
-  gitleaks_id,
-  code_data_source_id,
+const upsertGithubWithToken = `
+INSERT INTO code_github_setting (
+  code_github_setting_id,
   name,
   project_id,
   type,
   base_url,
   target_resource,
-  repository_pattern,
   github_user,
-  personal_access_token,
-  scan_public,
-  scan_internal,
-  scan_private,
-  gitleaks_config,
-  status,
-  status_detail,
-  scan_at,
-  scan_succeeded_at
+  personal_access_token
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
-	code_data_source_id=VALUES(code_data_source_id),
+	code_github_setting_id=VALUES(code_github_setting_id),
 	name=VALUES(name),
 	project_id=VALUES(project_id),
 	type=VALUES(type),
 	base_url=VALUES(base_url),
 	target_resource=VALUES(target_resource),
-	repository_pattern=VALUES(repository_pattern),
 	github_user=VALUES(github_user),
-	personal_access_token=VALUES(personal_access_token),
-	scan_public=VALUES(scan_public),
-	scan_internal=VALUES(scan_internal),
-	scan_private=VALUES(scan_private),
-	gitleaks_config=VALUES(gitleaks_config),
-	status=VALUES(status),
-	status_detail=VALUES(status_detail),
-	scan_at=VALUES(scan_at),
-	scan_succeeded_at=VALUES(scan_succeeded_at)
+	personal_access_token=VALUES(personal_access_token)
 `
 
-func (c *Client) UpsertGitleaksWithToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaks, error) {
-	var scanSucceededAtTime time.Time
-	if !zero.IsZeroVal(data.ScanSucceededAt) {
-		scanSucceededAtTime = time.Unix(data.ScanSucceededAt, 0)
-	}
-	if err := c.MasterDB.WithContext(ctx).Exec(insertUpsertGitleaksWithToken,
+func (c *Client) UpsertGithubSettingWithToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGithubWithToken,
 		data.GitleaksId,
-		data.CodeDataSourceId,
 		convertZeroValueToNull(data.Name),
 		data.ProjectId,
 		data.Type.String(),
 		data.BaseUrl,
 		data.TargetResource,
-		convertZeroValueToNull(data.RepositoryPattern),
 		convertZeroValueToNull(data.GithubUser),
-		convertZeroValueToNull(data.PersonalAccessToken),
-		fmt.Sprintf("%t", data.ScanPublic),
-		fmt.Sprintf("%t", data.ScanInternal),
-		fmt.Sprintf("%t", data.ScanPrivate),
-		convertZeroValueToNull(data.GitleaksConfig),
-		data.Status.String(),
-		convertZeroValueToNull(data.StatusDetail),
-		time.Unix(data.ScanAt, 0),
-		convertZeroValueToNull(scanSucceededAtTime)).Error; err != nil {
+		convertZeroValueToNull(data.PersonalAccessToken)).Error; err != nil {
 		return nil, err
 	}
-	return c.GetGitleaksByUniqueIndex(ctx, data.ProjectId, data.CodeDataSourceId, data.Name)
+	return c.GetGithubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
 }
 
-const insertUpsertGitleaksWithoutToken = `
-INSERT INTO code_gitleaks (
-  gitleaks_id,
-  code_data_source_id,
+const upsertGithubSettingWithoutToken = `
+INSERT INTO code_github_setting (
+  code_github_setting_id,
   name,
   project_id,
   type,
   base_url,
   target_resource,
-  repository_pattern,
-  github_user,
-  scan_public,
-  scan_internal,
-  scan_private,
-  gitleaks_config,
-  status,
-  status_detail,
-  scan_at,
-  scan_succeeded_at
+  github_user
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
-	code_data_source_id=VALUES(code_data_source_id),
+	code_github_setting_id=VALUES(code_github_setting_id),
 	name=VALUES(name),
 	project_id=VALUES(project_id),
 	type=VALUES(type),
 	base_url=VALUES(base_url),
 	target_resource=VALUES(target_resource),
-	repository_pattern=VALUES(repository_pattern),
-	github_user=VALUES(github_user),
-	scan_public=VALUES(scan_public),
-	scan_internal=VALUES(scan_internal),
-	scan_private=VALUES(scan_private),
-	gitleaks_config=VALUES(gitleaks_config),
-	status=VALUES(status),
-	status_detail=VALUES(status_detail),
-	scan_at=VALUES(scan_at),
-	scan_succeeded_at=VALUES(scan_succeeded_at)
+	github_user=VALUES(github_user)
 `
 
-func (c *Client) UpsertGitleaksWithoutToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaks, error) {
-	var scanSucceededAtTime time.Time
-	if !zero.IsZeroVal(data.ScanSucceededAt) {
-		scanSucceededAtTime = time.Unix(data.ScanSucceededAt, 0)
-	}
-	if err := c.MasterDB.WithContext(ctx).Exec(insertUpsertGitleaksWithoutToken,
+func (c *Client) UpsertGithubSettingWithoutToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGithubSettingWithoutToken,
 		data.GitleaksId,
-		data.CodeDataSourceId,
 		convertZeroValueToNull(data.Name),
 		data.ProjectId,
 		data.Type.String(),
 		data.BaseUrl,
 		data.TargetResource,
-		convertZeroValueToNull(data.RepositoryPattern),
-		convertZeroValueToNull(data.GithubUser),
-		fmt.Sprintf("%t", data.ScanPublic),
-		fmt.Sprintf("%t", data.ScanInternal),
-		fmt.Sprintf("%t", data.ScanPrivate),
-		convertZeroValueToNull(data.GitleaksConfig),
-		data.Status.String(),
-		convertZeroValueToNull(data.StatusDetail),
-		time.Unix(data.ScanAt, 0),
-		convertZeroValueToNull(scanSucceededAtTime)).Error; err != nil {
+		convertZeroValueToNull(data.GithubUser)).Error; err != nil {
 		return nil, err
 	}
-	return c.GetGitleaksByUniqueIndex(ctx, data.ProjectId, data.CodeDataSourceId, data.Name)
+	return c.GetGithubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
 }
 
-const deleteGitleaks = `delete from code_gitleaks where project_id=? and gitleaks_id=?`
-
-func (c *Client) DeleteGitleaks(ctx context.Context, projectID, gitleaksID uint32) error {
-	if err := c.MasterDB.WithContext(ctx).Exec(deleteGitleaks, projectID, gitleaksID).Error; err != nil {
+func (c *Client) DeleteGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).Delete(&model.CodeGithubSetting{}).Error; err != nil {
 		return err
 	}
 	return nil
 }
 
-const selectGetCodeGitleaks = `select * from code_gitleaks where project_id=? and gitleaks_id=?`
-
-func (c *Client) GetGitleaks(ctx context.Context, projectID, gitleaksID uint32) (*model.CodeGitleaks, error) {
-	data := model.CodeGitleaks{}
-	if err := c.SlaveDB.WithContext(ctx).Raw(selectGetCodeGitleaks, projectID, gitleaksID).First(&data).Error; err != nil {
+func (c *Client) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error) {
+	query := `select * from code_gitleaks_setting where and project_id = ?`
+	var params []interface{}
+	params = append(params, projectID)
+	data := []model.CodeGitleaksSetting{}
+	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-const selectGetCodeGitleaksByUniqueIndex = `select * from code_gitleaks where project_id=? and code_data_source_id=? and name=?`
-
-func (c *Client) GetGitleaksByUniqueIndex(ctx context.Context, projectID, codeDataSourceID uint32, name string) (*model.CodeGitleaks, error) {
-	data := model.CodeGitleaks{}
-	if err := c.MasterDB.WithContext(ctx).Raw(selectGetCodeGitleaksByUniqueIndex, projectID, codeDataSourceID, name).First(&data).Error; err != nil {
+func (c *Client) GetGitleaksSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*model.CodeGitleaksSetting, error) {
+	var data model.CodeGitleaksSetting
+	if err := c.SlaveDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) ListEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32) (*[]model.CodeEnterpriseOrg, error) {
-	query := `select * from code_enterprise_org where 1=1`
+const upsertGitleaksWithToken = `
+INSERT INTO code_gitleaks_setting (
+  code_github_setting_id,
+  code_data_source_id,
+  project_id,
+  repository_pattern,
+  scan_public,
+  scan_internal,
+  scan_private,
+  status,
+  status_detail,
+  scan_at
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	code_data_source_id=VALUES(code_data_source_id),
+	project_id=VALUES(project_id),
+	repository_pattern=VALUES(repository_pattern),
+	scan_public=VALUES(scan_public),
+	scan_internal=VALUES(scan_internal),
+	scan_private=VALUES(scan_private),
+	status=VALUES(status),
+	status_detail=VALUES(status_detail),
+	scan_at=VALUES(scan_at)
+`
+
+func (c *Client) UpsertGitleaksSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaksSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGitleaksWithToken,
+		data.GitleaksId,
+		data.CodeDataSourceId,
+		data.ProjectId,
+		convertZeroValueToNull(data.RepositoryPattern),
+		fmt.Sprintf("%t", data.ScanPublic),
+		fmt.Sprintf("%t", data.ScanInternal),
+		fmt.Sprintf("%t", data.ScanPrivate),
+		data.Status.String(),
+		convertZeroValueToNull(data.StatusDetail),
+		time.Unix(data.ScanAt, 0)).Error; err != nil {
+		return nil, err
+	}
+	return c.GetGitleaksSetting(ctx, data.ProjectId, data.GitleaksId)
+
+}
+
+func (c *Client) DeleteGitleaksSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).Delete(&model.CodeGitleaksSetting{}).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+const selectGetCodeGithubSettingByUniqueIndex = `select * from code_github_setting where project_id=? and name=?`
+
+func (c *Client) GetGithubSettingByUniqueIndex(ctx context.Context, projectID uint32, name string) (*model.CodeGithubSetting, error) {
+	data := model.CodeGithubSetting{}
+	if err := c.MasterDB.WithContext(ctx).Raw(selectGetCodeGithubSettingByUniqueIndex, projectID, name).First(&data).Error; err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+func (c *Client) ListGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error) {
+	query := `select * from code_github_enterprise_org where 1=1`
 	var params []interface{}
 	if !zero.IsZeroVal(projectID) {
 		query += " and project_id=?"
 		params = append(params, projectID)
 	}
-	if !zero.IsZeroVal(gitleaksID) {
-		query += " and gitleaks_id=?"
-		params = append(params, gitleaksID)
+	if !zero.IsZeroVal(githubSettingID) {
+		query += " and code_github_setting_id=?"
+		params = append(params, githubSettingID)
 	}
-	data := []model.CodeEnterpriseOrg{}
+	data := []model.CodeGithubEnterpriseOrg{}
 	if err := c.MasterDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) UpsertEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeEnterpriseOrg, error) {
-	var updated model.CodeEnterpriseOrg
+func (c *Client) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error) {
+	var updated model.CodeGithubEnterpriseOrg
 	if err := c.MasterDB.WithContext(ctx).
-		Where("gitleaks_id=? and login=? and project_id=?", data.GitleaksId, data.Login, data.ProjectId).
+		Where("code_github_setting_id=? and organization=? and project_id=?", data.GitleaksId, data.Login, data.ProjectId).
 		Assign(map[string]interface{}{
-			"gitleaks_id": data.GitleaksId,
-			"login":       data.Login,
-			"project_id":  data.ProjectId,
+			"code_github_setting_id": data.GitleaksId,
+			"organization":           data.Login,
+			"project_id":             data.ProjectId,
 		}).
 		FirstOrCreate(&updated).
 		Error; err != nil {
 		return nil, err
 	}
-	return &model.CodeEnterpriseOrg{
-		GitleaksID: updated.GitleaksID,
-		Login:      updated.Login,
-		ProjectID:  data.ProjectId,
-		UpdatedAt:  updated.UpdatedAt,
-		CreatedAt:  updated.CreatedAt,
+	return &model.CodeGithubEnterpriseOrg{
+		CodeGithubSettingID: updated.CodeGithubSettingID,
+		Organization:        updated.Organization,
+		ProjectID:           data.ProjectId,
+		UpdatedAt:           updated.UpdatedAt,
+		CreatedAt:           updated.CreatedAt,
 	}, nil
 }
 
-const deleteEnterpriseOrg = `delete from code_enterprise_org where project_id=? and gitleaks_id=? and login=?`
-
-func (c *Client) DeleteEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32, login string) error {
-	if err := c.MasterDB.WithContext(ctx).Exec(deleteEnterpriseOrg, projectID, gitleaksID, login).Error; err != nil {
+func (c *Client) DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ? AND organization = ?", projectID, githubSettingID, organization).Delete(&model.CodeGithubEnterpriseOrg{}).Error; err != nil {
 		return err
 	}
 	return nil

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -15,21 +15,21 @@ type CodeRepoInterface interface {
 	ListCodeDataSource(ctx context.Context, codeDataSourceID uint32, name string) (*[]model.CodeDataSource, error)
 
 	// code_github_setting
-	ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error)
-	GetGithubSetting(ctx context.Context, projectID, GithubSettingID uint32) (*model.CodeGithubSetting, error)
-	UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error)
-	DeleteGithubSetting(ctx context.Context, projectID uint32, GithubSettingID uint32) error
+	ListGitHubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGitHubSetting, error)
+	GetGitHubSetting(ctx context.Context, projectID, GitHubSettingID uint32) (*model.CodeGitHubSetting, error)
+	UpsertGitHubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitHubSetting, error)
+	DeleteGitHubSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
 	// code_gitleaks_setting
 	ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error)
 	GetGitleaksSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGitleaksSetting, error)
 	UpsertGitleaksSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaksSetting, error)
-	DeleteGitleaksSetting(ctx context.Context, projectID uint32, GithubSettingID uint32) error
+	DeleteGitleaksSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
 	// code_github_enterprise_org
-	ListGithubEnterpriseOrg(ctx context.Context, projectID, GithubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error)
-	UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error)
-	DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error
+	ListGitHubEnterpriseOrg(ctx context.Context, projectID, GitHubSettingID uint32) (*[]model.CodeGitHubEnterpriseOrg, error)
+	UpsertGitHubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGitHubEnterpriseOrg, error)
+	DeleteGitHubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error
 }
 
 var _ CodeRepoInterface = (*Client)(nil) // verify interface compliance
@@ -52,7 +52,7 @@ func (c *Client) ListCodeDataSource(ctx context.Context, codeDataSourceID uint32
 	return &data, nil
 }
 
-func (c *Client) ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error) {
+func (c *Client) ListGitHubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGitHubSetting, error) {
 	query := `select * from code_github_setting where 1=1`
 	var params []interface{}
 	if !zero.IsZeroVal(projectID) {
@@ -63,29 +63,29 @@ func (c *Client) ListGithubSetting(ctx context.Context, projectID, githubSetting
 		query += " and code_github_setting_id = ?"
 		params = append(params, githubSettingID)
 	}
-	data := []model.CodeGithubSetting{}
+	data := []model.CodeGitHubSetting{}
 	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) GetGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*model.CodeGithubSetting, error) {
-	var data model.CodeGithubSetting
+func (c *Client) GetGitHubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*model.CodeGitHubSetting, error) {
+	var data model.CodeGitHubSetting
 	if err := c.SlaveDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
+func (c *Client) UpsertGitHubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitHubSetting, error) {
 	if data.PersonalAccessToken != "" {
-		return c.UpsertGithubSettingWithToken(ctx, data)
+		return c.UpsertGitHubSettingWithToken(ctx, data)
 	}
-	return c.UpsertGithubSettingWithoutToken(ctx, data)
+	return c.UpsertGitHubSettingWithoutToken(ctx, data)
 }
 
-const upsertGithubWithToken = `
+const upsertGitHubWithToken = `
 INSERT INTO code_github_setting (
   code_github_setting_id,
   name,
@@ -108,8 +108,8 @@ ON DUPLICATE KEY UPDATE
 	personal_access_token=VALUES(personal_access_token)
 `
 
-func (c *Client) UpsertGithubSettingWithToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
-	if err := c.MasterDB.WithContext(ctx).Exec(upsertGithubWithToken,
+func (c *Client) UpsertGitHubSettingWithToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitHubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGitHubWithToken,
 		data.GitleaksId,
 		convertZeroValueToNull(data.Name),
 		data.ProjectId,
@@ -120,10 +120,10 @@ func (c *Client) UpsertGithubSettingWithToken(ctx context.Context, data *code.Gi
 		convertZeroValueToNull(data.PersonalAccessToken)).Error; err != nil {
 		return nil, err
 	}
-	return c.GetGithubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
+	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
 }
 
-const upsertGithubSettingWithoutToken = `
+const upsertGitHubSettingWithoutToken = `
 INSERT INTO code_github_setting (
   code_github_setting_id,
   name,
@@ -144,8 +144,8 @@ ON DUPLICATE KEY UPDATE
 	github_user=VALUES(github_user)
 `
 
-func (c *Client) UpsertGithubSettingWithoutToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
-	if err := c.MasterDB.WithContext(ctx).Exec(upsertGithubSettingWithoutToken,
+func (c *Client) UpsertGitHubSettingWithoutToken(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitHubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGitHubSettingWithoutToken,
 		data.GitleaksId,
 		convertZeroValueToNull(data.Name),
 		data.ProjectId,
@@ -155,11 +155,11 @@ func (c *Client) UpsertGithubSettingWithoutToken(ctx context.Context, data *code
 		convertZeroValueToNull(data.GithubUser)).Error; err != nil {
 		return nil, err
 	}
-	return c.GetGithubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
+	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
 }
 
-func (c *Client) DeleteGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
-	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).Delete(&model.CodeGithubSetting{}).Error; err != nil {
+func (c *Client) DeleteGitHubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).Delete(&model.CodeGitHubSetting{}).Error; err != nil {
 		return err
 	}
 	return nil
@@ -235,17 +235,17 @@ func (c *Client) DeleteGitleaksSetting(ctx context.Context, projectID uint32, gi
 	return nil
 }
 
-const selectGetCodeGithubSettingByUniqueIndex = `select * from code_github_setting where project_id=? and name=?`
+const selectGetCodeGitHubSettingByUniqueIndex = `select * from code_github_setting where project_id=? and name=?`
 
-func (c *Client) GetGithubSettingByUniqueIndex(ctx context.Context, projectID uint32, name string) (*model.CodeGithubSetting, error) {
-	data := model.CodeGithubSetting{}
-	if err := c.MasterDB.WithContext(ctx).Raw(selectGetCodeGithubSettingByUniqueIndex, projectID, name).First(&data).Error; err != nil {
+func (c *Client) GetGitHubSettingByUniqueIndex(ctx context.Context, projectID uint32, name string) (*model.CodeGitHubSetting, error) {
+	data := model.CodeGitHubSetting{}
+	if err := c.MasterDB.WithContext(ctx).Raw(selectGetCodeGitHubSettingByUniqueIndex, projectID, name).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) ListGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error) {
+func (c *Client) ListGitHubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGitHubEnterpriseOrg, error) {
 	query := `select * from code_github_enterprise_org where 1=1`
 	var params []interface{}
 	if !zero.IsZeroVal(projectID) {
@@ -256,15 +256,15 @@ func (c *Client) ListGithubEnterpriseOrg(ctx context.Context, projectID, githubS
 		query += " and code_github_setting_id=?"
 		params = append(params, githubSettingID)
 	}
-	data := []model.CodeGithubEnterpriseOrg{}
+	data := []model.CodeGitHubEnterpriseOrg{}
 	if err := c.MasterDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (c *Client) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error) {
-	var updated model.CodeGithubEnterpriseOrg
+func (c *Client) UpsertGitHubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGitHubEnterpriseOrg, error) {
+	var updated model.CodeGitHubEnterpriseOrg
 	if err := c.MasterDB.WithContext(ctx).
 		Where("code_github_setting_id=? and organization=? and project_id=?", data.GitleaksId, data.Login, data.ProjectId).
 		Assign(map[string]interface{}{
@@ -276,8 +276,8 @@ func (c *Client) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.Enter
 		Error; err != nil {
 		return nil, err
 	}
-	return &model.CodeGithubEnterpriseOrg{
-		CodeGithubSettingID: updated.CodeGithubSettingID,
+	return &model.CodeGitHubEnterpriseOrg{
+		CodeGitHubSettingID: updated.CodeGitHubSettingID,
 		Organization:        updated.Organization,
 		ProjectID:           data.ProjectId,
 		UpdatedAt:           updated.UpdatedAt,
@@ -285,8 +285,8 @@ func (c *Client) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.Enter
 	}, nil
 }
 
-func (c *Client) DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
-	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ? AND organization = ?", projectID, githubSettingID, organization).Delete(&model.CodeGithubEnterpriseOrg{}).Error; err != nil {
+func (c *Client) DeleteGitHubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ? AND organization = ?", projectID, githubSettingID, organization).Delete(&model.CodeGitHubEnterpriseOrg{}).Error; err != nil {
 		return err
 	}
 	return nil

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -1,0 +1,728 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ca-risken/datasource-api/pkg/model"
+	"github.com/ca-risken/datasource-api/proto/code"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func newDBMock() (*Client, sqlmock.Sqlmock, error) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open mock sql db, error: %+w", err)
+	}
+	if sqlDB == nil {
+		return nil, nil, fmt.Errorf("failed to create mock db, db: %+v, mock: %+v", sqlDB, mock)
+	}
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{NamingStrategy: schema.NamingStrategy{SingularTable: true}})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open gorm, error: %+w", err)
+	}
+	return &Client{
+		MasterDB: gormDB,
+		SlaveDB:  gormDB,
+	}, mock, nil
+}
+
+func TestListGitHubSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *[]model.CodeGitHubSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK no param",
+			args: args{ProjectID: 0, CodeGitHubSettingID: 0},
+			want: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, Name: "github_setting2", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_setting where 1=1")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "USER", "target", now, now).
+					AddRow(uint32(2), "github_setting2", uint32(1), "USER", "target", now, now))
+			},
+		},
+		{
+			name: "OK (project_id)",
+			args: args{ProjectID: 1, CodeGitHubSettingID: 0},
+			want: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, Name: "github_setting2", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_setting where 1=1 and project_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "USER", "target", now, now).
+					AddRow(uint32(2), "github_setting2", uint32(1), "USER", "target", now, now))
+			},
+		},
+		{
+			name: "OK (code_github_setting_id)",
+			args: args{ProjectID: 0, CodeGitHubSettingID: 1},
+			want: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, Name: "github_setting2", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_setting where 1=1 and code_github_setting_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "USER", "target", now, now).
+					AddRow(uint32(2), "github_setting2", uint32(1), "USER", "target", now, now))
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_setting where 1=1 and project_id = ? and code_github_setting_id = ?")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.ListGitHubSetting(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestGetGitHubSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *model.CodeGitHubSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "USER", TargetResource: "target", CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "USER", "target", now, now))
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.GetGitHubSetting(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestUpsertGitHubSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		data *code.GitleaksForUpsert
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *model.CodeGitHubSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK with token",
+			args: args{
+				data: &code.GitleaksForUpsert{GitleaksId: 1, CodeDataSourceId: 1, Name: "name", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token", CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubWithToken)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "personal_access_token", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "ENTERPRISE", "target", "user", "token", now, now))
+			},
+		},
+		{
+			name: "OK without token",
+			args: args{
+				data: &code.GitleaksForUpsert{GitleaksId: 1, CodeDataSourceId: 1, Name: "name", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", GithubUser: "user"},
+			},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token", CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubSettingWithoutToken)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "personal_access_token", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "ENTERPRISE", "target", "user", "token", now, now))
+			},
+		},
+		{
+			name: "NG DB error",
+			args: args{
+				data: &code.GitleaksForUpsert{GitleaksId: 1, CodeDataSourceId: 1, Name: "name", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubWithToken)).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.UpsertGitHubSetting(ctx, c.args.data)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestDeleteGitHubSetting(t *testing.T) {
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnError(errors.New("DB error"))
+				mock.ExpectRollback()
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			err = db.DeleteGitHubSetting(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestListGitleaksSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		ProjectID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *[]model.CodeGitleaksSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK",
+			args: args{ProjectID: 1},
+			want: &[]model.CodeGitleaksSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: false, ScanInternal: true, ScanPrivate: false, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_gitleaks_setting where project_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "code_data_source_id", "project_id", "scan_public", "scan_internal", "scan_private", "status", "scan_at", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), uint32(1), true, true, true, "OK", now, now, now).
+					AddRow(uint32(2), uint32(1), uint32(1), false, true, false, "OK", now, now, now))
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_gitleaks_setting where project_id = ?")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.ListGitleaksSetting(ctx, c.args.ProjectID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestGetGitleaksSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *model.CodeGitleaksSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			want:    &model.CodeGitleaksSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_gitleaks_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "code_data_source_id", "project_id", "scan_public", "scan_internal", "scan_private", "status", "scan_at", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), uint32(1), true, true, true, "OK", now, now, now))
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_gitleaks_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.GetGitleaksSetting(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestUpsertGitleaksSetting(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		data *code.GitleaksForUpsert
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *model.CodeGitleaksSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK",
+			args: args{
+				data: &code.GitleaksForUpsert{GitleaksId: 1, CodeDataSourceId: 1, Name: "name", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: code.Status_OK, StatusDetail: "detail", GithubUser: "user", PersonalAccessToken: "token", ScanAt: now.Unix()},
+			},
+			want:    &model.CodeGitleaksSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitleaksWithToken)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_gitleaks_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "code_data_source_id", "project_id", "scan_public", "scan_internal", "scan_private", "status", "scan_at", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), uint32(1), true, true, true, "OK", now, now, now))
+			},
+		},
+		{
+			name: "NG DB error",
+			args: args{
+				data: &code.GitleaksForUpsert{GitleaksId: 1, CodeDataSourceId: 1, Name: "name", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: code.Status_OK, StatusDetail: "detail", GithubUser: "user", PersonalAccessToken: "token", ScanAt: now.Unix()},
+			},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitleaksWithToken)).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.UpsertGitleaksSetting(ctx, c.args.data)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestDeleteGitleaksSetting(t *testing.T) {
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_gitleaks_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1},
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_gitleaks_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnError(errors.New("DB error"))
+				mock.ExpectRollback()
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			err = db.DeleteGitleaksSetting(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestListGithubEnterpriseOrg(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		ProjectID           uint32
+		CodeGithubSettingID uint32
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		want        *[]model.CodeGitHubEnterpriseOrg
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK",
+			args: args{ProjectID: 1, CodeGithubSettingID: 1},
+			want: &[]model.CodeGitHubEnterpriseOrg{
+				{CodeGitHubSettingID: 1, Organization: "org1", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 1, Organization: "org2", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_enterprise_org where 1=1 and project_id=? and code_github_setting_id=?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "project_id", "organization", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), "org1", now, now).
+					AddRow(uint32(1), uint32(1), "org2", now, now))
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGithubSettingID: 1},
+			want:    nil,
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_github_enterprise_org where 1=1 and project_id=? and code_github_setting_id=?")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.ListGitHubEnterpriseOrg(ctx, c.args.ProjectID, c.args.CodeGithubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestUpsertGithubEnterpriseOrg(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		data *code.EnterpriseOrgForUpsert
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK Update",
+			args: args{
+				data: &code.EnterpriseOrgForUpsert{GitleaksId: 1, Login: "name", ProjectId: 1},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_enterprise_org`")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "project_id", "organization", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), "org1", now, now))
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE `code_github_enterprise_org`")).WithArgs().WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name: "OK Insert",
+			args: args{
+				data: &code.EnterpriseOrgForUpsert{GitleaksId: 1, Login: "name", ProjectId: 1},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_enterprise_org`")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "project_id", "organization", "created_at", "updated_at"}))
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `code_github_enterprise_org`")).WithArgs().WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name: "NG DB error",
+			args: args{
+				data: &code.EnterpriseOrgForUpsert{GitleaksId: 1, Login: "name", ProjectId: 1},
+			},
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_enterprise_org`")).WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			_, err = db.UpsertGitHubEnterpriseOrg(ctx, c.args.data)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestDeleteGithubEnterpriseOrg(t *testing.T) {
+	type args struct {
+		ProjectID           uint32
+		CodeGitHubSettingID uint32
+		Organization        string
+	}
+
+	cases := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1, Organization: "org"},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_github_enterprise_org` WHERE project_id = ? AND code_github_setting_id = ? AND organization = ?")).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name:    "NG DB error",
+			args:    args{ProjectID: 1, CodeGitHubSettingID: 1, Organization: "org"},
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `code_github_enterprise_org` WHERE project_id = ? AND code_github_setting_id = ? AND organization = ?")).WillReturnResult(sqlmock.NewResult(1, 1))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			err = db.DeleteGitHubEnterpriseOrg(ctx, c.args.ProjectID, c.args.CodeGitHubSettingID, c.args.Organization)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}

--- a/pkg/db/mock/code.go
+++ b/pkg/db/mock/code.go
@@ -19,21 +19,21 @@ func (m *MockCodeRepository) ListCodeDataSource(ctx context.Context, codeDataSou
 	args := m.Called()
 	return args.Get(0).(*[]model.CodeDataSource), args.Error(1)
 }
-func (m *MockCodeRepository) ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error) {
+func (m *MockCodeRepository) ListGitHubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGitHubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*[]model.CodeGithubSetting), args.Error(1)
+	return args.Get(0).(*[]model.CodeGitHubSetting), args.Error(1)
 }
-func (m *MockCodeRepository) UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
+func (m *MockCodeRepository) UpsertGitHubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitHubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeGithubSetting), args.Error(1)
+	return args.Get(0).(*model.CodeGitHubSetting), args.Error(1)
 }
-func (m *MockCodeRepository) DeleteGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
+func (m *MockCodeRepository) DeleteGitHubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockCodeRepository) GetGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGithubSetting, error) {
+func (m *MockCodeRepository) GetGitHubSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGitHubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeGithubSetting), args.Error(1)
+	return args.Get(0).(*model.CodeGitHubSetting), args.Error(1)
 }
 func (m *MockCodeRepository) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error) {
 	args := m.Called()
@@ -51,15 +51,15 @@ func (m *MockCodeRepository) DeleteGitleaksSetting(ctx context.Context, projectI
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockCodeRepository) ListGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error) {
+func (m *MockCodeRepository) ListGitHubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGitHubEnterpriseOrg, error) {
 	args := m.Called()
-	return args.Get(0).(*[]model.CodeGithubEnterpriseOrg), args.Error(1)
+	return args.Get(0).(*[]model.CodeGitHubEnterpriseOrg), args.Error(1)
 }
-func (m *MockCodeRepository) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error) {
+func (m *MockCodeRepository) UpsertGitHubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGitHubEnterpriseOrg, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeGithubEnterpriseOrg), args.Error(1)
+	return args.Get(0).(*model.CodeGitHubEnterpriseOrg), args.Error(1)
 }
-func (m *MockCodeRepository) DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
+func (m *MockCodeRepository) DeleteGitHubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/pkg/db/mock/code.go
+++ b/pkg/db/mock/code.go
@@ -19,31 +19,47 @@ func (m *MockCodeRepository) ListCodeDataSource(ctx context.Context, codeDataSou
 	args := m.Called()
 	return args.Get(0).(*[]model.CodeDataSource), args.Error(1)
 }
-func (m *MockCodeRepository) ListGitleaks(ctx context.Context, projectID, codeDataSourceID, gitleaksID uint32) (*[]model.CodeGitleaks, error) {
+func (m *MockCodeRepository) ListGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*[]model.CodeGitleaks), args.Error(1)
+	return args.Get(0).(*[]model.CodeGithubSetting), args.Error(1)
 }
-func (m *MockCodeRepository) UpsertGitleaks(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaks, error) {
+func (m *MockCodeRepository) UpsertGithubSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGithubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeGitleaks), args.Error(1)
+	return args.Get(0).(*model.CodeGithubSetting), args.Error(1)
 }
-func (m *MockCodeRepository) DeleteGitleaks(ctx context.Context, projectID uint32, gitleaksID uint32) error {
+func (m *MockCodeRepository) DeleteGithubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockCodeRepository) GetGitleaks(ctx context.Context, projectID, gitleaksID uint32) (*model.CodeGitleaks, error) {
+func (m *MockCodeRepository) GetGithubSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGithubSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeGitleaks), args.Error(1)
+	return args.Get(0).(*model.CodeGithubSetting), args.Error(1)
 }
-func (m *MockCodeRepository) ListEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32) (*[]model.CodeEnterpriseOrg, error) {
+func (m *MockCodeRepository) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*[]model.CodeEnterpriseOrg), args.Error(1)
+	return args.Get(0).(*[]model.CodeGitleaksSetting), args.Error(1)
 }
-func (m *MockCodeRepository) UpsertEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeEnterpriseOrg, error) {
+func (m *MockCodeRepository) GetGitleaksSetting(ctx context.Context, projectID, githubSettingID uint32) (*model.CodeGitleaksSetting, error) {
 	args := m.Called()
-	return args.Get(0).(*model.CodeEnterpriseOrg), args.Error(1)
+	return args.Get(0).(*model.CodeGitleaksSetting), args.Error(1)
 }
-func (m *MockCodeRepository) DeleteEnterpriseOrg(ctx context.Context, projectID, gitleaksID uint32, login string) error {
+func (m *MockCodeRepository) UpsertGitleaksSetting(ctx context.Context, data *code.GitleaksForUpsert) (*model.CodeGitleaksSetting, error) {
+	args := m.Called()
+	return args.Get(0).(*model.CodeGitleaksSetting), args.Error(1)
+}
+func (m *MockCodeRepository) DeleteGitleaksSetting(ctx context.Context, projectID uint32, githubSettingID uint32) error {
+	args := m.Called()
+	return args.Error(0)
+}
+func (m *MockCodeRepository) ListGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32) (*[]model.CodeGithubEnterpriseOrg, error) {
+	args := m.Called()
+	return args.Get(0).(*[]model.CodeGithubEnterpriseOrg), args.Error(1)
+}
+func (m *MockCodeRepository) UpsertGithubEnterpriseOrg(ctx context.Context, data *code.EnterpriseOrgForUpsert) (*model.CodeGithubEnterpriseOrg, error) {
+	args := m.Called()
+	return args.Get(0).(*model.CodeGithubEnterpriseOrg), args.Error(1)
+}
+func (m *MockCodeRepository) DeleteGithubEnterpriseOrg(ctx context.Context, projectID, githubSettingID uint32, organization string) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/pkg/model/code.go
+++ b/pkg/model/code.go
@@ -12,35 +12,41 @@ type CodeDataSource struct {
 	UpdatedAt        time.Time
 }
 
-// CodeGitleaks entity
-type CodeGitleaks struct {
-	GitleaksID          uint32 `gorm:"primary_key"`
-	CodeDataSourceID    uint32
+// CodeGithubSetting entity
+type CodeGithubSetting struct {
+	CodeGithubSettingID uint32 `gorm:"primary_key"`
 	Name                string
 	ProjectID           uint32
 	Type                string
 	BaseURL             string
 	TargetResource      string
-	RepositoryPattern   string
 	GithubUser          string
 	PersonalAccessToken string
-	ScanPublic          bool
-	ScanInternal        bool
-	ScanPrivate         bool
-	GitleaksConfig      string
-	Status              string
-	StatusDetail        string
-	ScanAt              time.Time
-	ScanSucceededAt     *time.Time
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
 
-// CodeEnterpriseOrg entity
-type CodeEnterpriseOrg struct {
-	GitleaksID uint32 `gorm:"primary_key"`
-	Login      string `gorm:"primary_key"`
-	ProjectID  uint32
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+// CodeGitleaksSetting entity
+type CodeGitleaksSetting struct {
+	CodeGithubSettingID uint32 `gorm:"primary_key"`
+	CodeDataSourceID    uint32
+	ProjectID           uint32
+	RepositoryPattern   string
+	ScanPublic          bool
+	ScanInternal        bool
+	ScanPrivate         bool
+	Status              string
+	StatusDetail        string
+	ScanAt              time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// CodeGithubEnterpriseOrg entity
+type CodeGithubEnterpriseOrg struct {
+	CodeGithubSettingID uint32 `gorm:"primary_key"`
+	Organization        string `gorm:"primary_key"`
+	ProjectID           uint32
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }

--- a/pkg/model/code.go
+++ b/pkg/model/code.go
@@ -12,23 +12,27 @@ type CodeDataSource struct {
 	UpdatedAt        time.Time
 }
 
-// CodeGithubSetting entity
-type CodeGithubSetting struct {
-	CodeGithubSettingID uint32 `gorm:"primary_key"`
+// CodeGitHubSetting entity
+type CodeGitHubSetting struct {
+	CodeGitHubSettingID uint32 `gorm:"primary_key;column:code_github_setting_id"`
 	Name                string
 	ProjectID           uint32
 	Type                string
 	BaseURL             string
 	TargetResource      string
-	GithubUser          string
+	GitHubUser          string `gorm:"column:github_user"`
 	PersonalAccessToken string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
 
+func (CodeGitHubSetting) TableName() string {
+	return "code_github_setting"
+}
+
 // CodeGitleaksSetting entity
 type CodeGitleaksSetting struct {
-	CodeGithubSettingID uint32 `gorm:"primary_key"`
+	CodeGitHubSettingID uint32 `gorm:"primary_key;column:code_github_setting_id"`
 	CodeDataSourceID    uint32
 	ProjectID           uint32
 	RepositoryPattern   string
@@ -42,9 +46,9 @@ type CodeGitleaksSetting struct {
 	UpdatedAt           time.Time
 }
 
-// CodeGithubEnterpriseOrg entity
-type CodeGithubEnterpriseOrg struct {
-	CodeGithubSettingID uint32 `gorm:"primary_key"`
+// CodeGitHubEnterpriseOrg entity
+type CodeGitHubEnterpriseOrg struct {
+	CodeGitHubSettingID uint32 `gorm:"primary_key;column:code_github_setting_id"`
 	Organization        string `gorm:"primary_key"`
 	ProjectID           uint32
 	CreatedAt           time.Time

--- a/pkg/model/code.go
+++ b/pkg/model/code.go
@@ -54,3 +54,7 @@ type CodeGitHubEnterpriseOrg struct {
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }
+
+func (CodeGitHubEnterpriseOrg) TableName() string {
+	return "code_github_enterprise_org"
+}

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -50,13 +50,13 @@ func (c *CodeService) ListDataSource(ctx context.Context, req *code.ListDataSour
 
 const maskData = "xxxxxxxxxx"
 
-func convertGitleaks(githubSetting *model.CodeGithubSetting, gitleaksSetting *model.CodeGitleaksSetting, maskKey bool) *code.Gitleaks {
+func convertGitleaks(githubSetting *model.CodeGitHubSetting, gitleaksSetting *model.CodeGitleaksSetting, maskKey bool) *code.Gitleaks {
 	var gitleaks code.Gitleaks
 	if githubSetting == nil && gitleaksSetting == nil {
 		return &gitleaks
 	}
 	gitleaks = code.Gitleaks{
-		GitleaksId:          githubSetting.CodeGithubSettingID,
+		GitleaksId:          githubSetting.CodeGitHubSettingID,
 		CodeDataSourceId:    gitleaksSetting.CodeDataSourceID,
 		Name:                githubSetting.Name,
 		ProjectId:           githubSetting.ProjectID,
@@ -64,7 +64,7 @@ func convertGitleaks(githubSetting *model.CodeGithubSetting, gitleaksSetting *mo
 		BaseUrl:             githubSetting.BaseURL,
 		TargetResource:      githubSetting.TargetResource,
 		RepositoryPattern:   gitleaksSetting.RepositoryPattern,
-		GithubUser:          githubSetting.GithubUser,
+		GithubUser:          githubSetting.GitHubUser,
 		PersonalAccessToken: githubSetting.PersonalAccessToken,
 		ScanPublic:          gitleaksSetting.ScanPublic,
 		ScanInternal:        gitleaksSetting.ScanInternal,
@@ -87,13 +87,13 @@ func (c *CodeService) ListGitleaks(ctx context.Context, req *code.ListGitleaksRe
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	list, err := c.repository.ListGithubSetting(ctx, req.ProjectId, req.GitleaksId)
+	list, err := c.repository.ListGitHubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		return nil, err
 	}
 	data := code.ListGitleaksResponse{}
 	for _, d := range *list {
-		gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, d.ProjectID, d.CodeGithubSettingID)
+		gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, d.ProjectID, d.CodeGitHubSettingID)
 		if err != nil {
 			return nil, err
 		}
@@ -106,14 +106,14 @@ func (c *CodeService) GetGitleaks(ctx context.Context, req *code.GetGitleaksRequ
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	githubSetting, err := c.repository.GetGithubSetting(ctx, req.ProjectId, req.GitleaksId)
+	githubSetting, err := c.repository.GetGitHubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &code.GetGitleaksResponse{}, nil
 		}
 		return nil, err
 	}
-	gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, githubSetting.ProjectID, githubSetting.CodeGithubSettingID)
+	gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID)
 	if err != nil {
 		return nil, err
 	}
@@ -134,23 +134,23 @@ func (c *CodeService) PutGitleaks(ctx context.Context, req *code.PutGitleaksRequ
 	} else {
 		req.Gitleaks.PersonalAccessToken = "" // for not update token.
 	}
-	registeredGithubSetting, err := c.repository.UpsertGithubSetting(ctx, req.Gitleaks)
+	registeredGitHubSetting, err := c.repository.UpsertGitHubSetting(ctx, req.Gitleaks)
 	if err != nil {
 		return nil, err
 	}
-	req.Gitleaks.GitleaksId = registeredGithubSetting.CodeGithubSettingID
+	req.Gitleaks.GitleaksId = registeredGitHubSetting.CodeGitHubSettingID
 	registeredGitleaksSetting, err := c.repository.UpsertGitleaksSetting(ctx, req.Gitleaks)
 	if err != nil {
 		return nil, err
 	}
-	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registeredGithubSetting, registeredGitleaksSetting, true)}, nil
+	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registeredGitHubSetting, registeredGitleaksSetting, true)}, nil
 }
 
 func (c *CodeService) DeleteGitleaks(ctx context.Context, req *code.DeleteGitleaksRequest) (*empty.Empty, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := c.repository.DeleteGithubSetting(ctx, req.ProjectId, req.GitleaksId)
+	err := c.repository.DeleteGitHubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		return nil, err
 	}
@@ -158,12 +158,12 @@ func (c *CodeService) DeleteGitleaks(ctx context.Context, req *code.DeleteGitlea
 	if err != nil {
 		return nil, err
 	}
-	organizations, err := c.repository.ListGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
+	organizations, err := c.repository.ListGitHubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		return nil, err
 	}
 	for _, org := range *organizations {
-		err = c.repository.DeleteGithubEnterpriseOrg(ctx, org.ProjectID, org.CodeGithubSettingID, org.Organization)
+		err = c.repository.DeleteGitHubEnterpriseOrg(ctx, org.ProjectID, org.CodeGitHubSettingID, org.Organization)
 		if err != nil {
 			return nil, err
 		}
@@ -207,12 +207,12 @@ func getStatus(s string) code.Status {
 	}
 }
 
-func convertEnterpriseOrg(data *model.CodeGithubEnterpriseOrg) *code.EnterpriseOrg {
+func convertEnterpriseOrg(data *model.CodeGitHubEnterpriseOrg) *code.EnterpriseOrg {
 	if data == nil {
 		return &code.EnterpriseOrg{}
 	}
 	return &code.EnterpriseOrg{
-		GitleaksId: data.CodeGithubSettingID,
+		GitleaksId: data.CodeGitHubSettingID,
 		Login:      data.Organization,
 		ProjectId:  data.ProjectID,
 		CreatedAt:  data.CreatedAt.Unix(),
@@ -224,7 +224,7 @@ func (c *CodeService) ListEnterpriseOrg(ctx context.Context, req *code.ListEnter
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	list, err := c.repository.ListGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
+	list, err := c.repository.ListGitHubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &code.ListEnterpriseOrgResponse{}, nil
@@ -242,7 +242,7 @@ func (c *CodeService) PutEnterpriseOrg(ctx context.Context, req *code.PutEnterpr
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	registered, err := c.repository.UpsertGithubEnterpriseOrg(ctx, req.EnterpriseOrg)
+	registered, err := c.repository.UpsertGitHubEnterpriseOrg(ctx, req.EnterpriseOrg)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (c *CodeService) DeleteEnterpriseOrg(ctx context.Context, req *code.DeleteE
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := c.repository.DeleteGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId, req.Login)
+	err := c.repository.DeleteGitHubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId, req.Login)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 		return nil, err
 	}
 	resp, err := c.sqs.Send(ctx, c.sqs.CodeGitleaksQueueURL, &message.GitleaksQueueMessage{
-		GitleaksID: data.CodeGithubSettingID,
+		GitleaksID: data.CodeGitHubSettingID,
 		ProjectID:  data.ProjectID,
 		ScanOnly:   req.ScanOnly,
 	})
@@ -277,7 +277,7 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 		return nil, err
 	}
 	if _, err = c.repository.UpsertGitleaksSetting(ctx, &code.GitleaksForUpsert{
-		GitleaksId:        data.CodeGithubSettingID,
+		GitleaksId:        data.CodeGitHubSettingID,
 		CodeDataSourceId:  data.CodeDataSourceID,
 		ProjectId:         data.ProjectID,
 		RepositoryPattern: data.RepositoryPattern,
@@ -314,11 +314,11 @@ func (c *CodeService) InvokeScanAllGitleaks(ctx context.Context, _ *empty.Empty)
 			continue
 		}
 		if _, err := c.InvokeScanGitleaks(ctx, &code.InvokeScanGitleaksRequest{
-			GitleaksId: g.CodeGithubSettingID,
+			GitleaksId: g.CodeGitHubSettingID,
 			ProjectId:  g.ProjectID,
 			ScanOnly:   true,
 		}); err != nil {
-			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: code_github_setting_id=%d, err=%+v", g.CodeGithubSettingID, err)
+			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: code_github_setting_id=%d, err=%+v", g.CodeGitHubSettingID, err)
 			return nil, err
 		}
 	}

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -134,16 +134,16 @@ func (c *CodeService) PutGitleaks(ctx context.Context, req *code.PutGitleaksRequ
 	} else {
 		req.Gitleaks.PersonalAccessToken = "" // for not update token.
 	}
-	registerdGithubSetting, err := c.repository.UpsertGithubSetting(ctx, req.Gitleaks)
+	registeredGithubSetting, err := c.repository.UpsertGithubSetting(ctx, req.Gitleaks)
 	if err != nil {
 		return nil, err
 	}
-	req.Gitleaks.GitleaksId = registerdGithubSetting.CodeGithubSettingID
-	registerdGitleaksSetting, err := c.repository.UpsertGitleaksSetting(ctx, req.Gitleaks)
+	req.Gitleaks.GitleaksId = registeredGithubSetting.CodeGithubSettingID
+	registeredGitleaksSetting, err := c.repository.UpsertGitleaksSetting(ctx, req.Gitleaks)
 	if err != nil {
 		return nil, err
 	}
-	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registerdGithubSetting, registerdGitleaksSetting, true)}, nil
+	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registeredGithubSetting, registeredGitleaksSetting, true)}, nil
 }
 
 func (c *CodeService) DeleteGitleaks(ctx context.Context, req *code.DeleteGitleaksRequest) (*empty.Empty, error) {
@@ -242,11 +242,11 @@ func (c *CodeService) PutEnterpriseOrg(ctx context.Context, req *code.PutEnterpr
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	registerd, err := c.repository.UpsertGithubEnterpriseOrg(ctx, req.EnterpriseOrg)
+	registered, err := c.repository.UpsertGithubEnterpriseOrg(ctx, req.EnterpriseOrg)
 	if err != nil {
 		return nil, err
 	}
-	return &code.PutEnterpriseOrgResponse{EnterpriseOrg: convertEnterpriseOrg(registerd)}, nil
+	return &code.PutEnterpriseOrgResponse{EnterpriseOrg: convertEnterpriseOrg(registered)}, nil
 }
 
 func (c *CodeService) DeleteEnterpriseOrg(ctx context.Context, req *code.DeleteEnterpriseOrgRequest) (*empty.Empty, error) {

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -50,57 +50,54 @@ func (c *CodeService) ListDataSource(ctx context.Context, req *code.ListDataSour
 
 const maskData = "xxxxxxxxxx"
 
-func convertGitleaks(data *model.CodeGitleaks, maskKey bool) *code.Gitleaks {
-	var gitlekas code.Gitleaks
-	if data == nil {
-		return &gitlekas
+func convertGitleaks(githubSetting *model.CodeGithubSetting, gitleaksSetting *model.CodeGitleaksSetting, maskKey bool) *code.Gitleaks {
+	var gitleaks code.Gitleaks
+	if githubSetting == nil && gitleaksSetting == nil {
+		return &gitleaks
 	}
-	gitlekas = code.Gitleaks{
-		GitleaksId:          data.GitleaksID,
-		CodeDataSourceId:    data.CodeDataSourceID,
-		Name:                data.Name,
-		ProjectId:           data.ProjectID,
-		Type:                getType(data.Type),
-		BaseUrl:             data.BaseURL,
-		TargetResource:      data.TargetResource,
-		RepositoryPattern:   data.RepositoryPattern,
-		GithubUser:          data.GithubUser,
-		PersonalAccessToken: data.PersonalAccessToken,
-		ScanPublic:          data.ScanPublic,
-		ScanInternal:        data.ScanInternal,
-		ScanPrivate:         data.ScanPrivate,
-		GitleaksConfig:      data.GitleaksConfig,
-		Status:              getStatus(data.Status),
-		StatusDetail:        data.StatusDetail,
-		CreatedAt:           data.CreatedAt.Unix(),
-		UpdatedAt:           data.UpdatedAt.Unix(),
+	gitleaks = code.Gitleaks{
+		GitleaksId:          githubSetting.CodeGithubSettingID,
+		CodeDataSourceId:    gitleaksSetting.CodeDataSourceID,
+		Name:                githubSetting.Name,
+		ProjectId:           githubSetting.ProjectID,
+		Type:                getType(githubSetting.Type),
+		BaseUrl:             githubSetting.BaseURL,
+		TargetResource:      githubSetting.TargetResource,
+		RepositoryPattern:   gitleaksSetting.RepositoryPattern,
+		GithubUser:          githubSetting.GithubUser,
+		PersonalAccessToken: githubSetting.PersonalAccessToken,
+		ScanPublic:          gitleaksSetting.ScanPublic,
+		ScanInternal:        gitleaksSetting.ScanInternal,
+		ScanPrivate:         gitleaksSetting.ScanPrivate,
+		Status:              getStatus(gitleaksSetting.Status),
+		StatusDetail:        gitleaksSetting.StatusDetail,
+		CreatedAt:           gitleaksSetting.CreatedAt.Unix(),
+		UpdatedAt:           gitleaksSetting.UpdatedAt.Unix(),
 	}
-	if gitlekas.PersonalAccessToken != "" && maskKey {
-		gitlekas.PersonalAccessToken = maskData // Masking sensitive data.
+	if gitleaks.PersonalAccessToken != "" && maskKey {
+		gitleaks.PersonalAccessToken = maskData // Masking sensitive data.
 	}
-	if !zero.IsZeroVal(data.ScanAt) {
-		gitlekas.ScanAt = data.ScanAt.Unix()
+	if !zero.IsZeroVal(gitleaksSetting.ScanAt) {
+		gitleaks.ScanAt = gitleaksSetting.ScanAt.Unix()
 	}
-	if !zero.IsZeroVal(data.ScanSucceededAt) {
-		gitlekas.ScanSucceededAt = data.ScanSucceededAt.Unix()
-	}
-	return &gitlekas
+	return &gitleaks
 }
 
 func (c *CodeService) ListGitleaks(ctx context.Context, req *code.ListGitleaksRequest) (*code.ListGitleaksResponse, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	list, err := c.repository.ListGitleaks(ctx, req.ProjectId, req.CodeDataSourceId, req.GitleaksId)
+	list, err := c.repository.ListGithubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return &code.ListGitleaksResponse{}, nil
-		}
 		return nil, err
 	}
 	data := code.ListGitleaksResponse{}
 	for _, d := range *list {
-		data.Gitleaks = append(data.Gitleaks, convertGitleaks(&d, true))
+		gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, d.ProjectID, d.CodeGithubSettingID)
+		if err != nil {
+			return nil, err
+		}
+		data.Gitleaks = append(data.Gitleaks, convertGitleaks(&d, gitleaksSetting, true))
 	}
 	return &data, nil
 }
@@ -109,14 +106,18 @@ func (c *CodeService) GetGitleaks(ctx context.Context, req *code.GetGitleaksRequ
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	data, err := c.repository.GetGitleaks(ctx, req.ProjectId, req.GitleaksId)
+	githubSetting, err := c.repository.GetGithubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &code.GetGitleaksResponse{}, nil
 		}
 		return nil, err
 	}
-	return &code.GetGitleaksResponse{Gitleaks: convertGitleaks(data, false)}, nil
+	gitleaksSetting, err := c.repository.GetGitleaksSetting(ctx, githubSetting.ProjectID, githubSetting.CodeGithubSettingID)
+	if err != nil {
+		return nil, err
+	}
+	return &code.GetGitleaksResponse{Gitleaks: convertGitleaks(githubSetting, gitleaksSetting, false)}, nil
 }
 
 func (c *CodeService) PutGitleaks(ctx context.Context, req *code.PutGitleaksRequest) (*code.PutGitleaksResponse, error) {
@@ -133,20 +134,39 @@ func (c *CodeService) PutGitleaks(ctx context.Context, req *code.PutGitleaksRequ
 	} else {
 		req.Gitleaks.PersonalAccessToken = "" // for not update token.
 	}
-	registerd, err := c.repository.UpsertGitleaks(ctx, req.Gitleaks)
+	registerdGithubSetting, err := c.repository.UpsertGithubSetting(ctx, req.Gitleaks)
 	if err != nil {
 		return nil, err
 	}
-	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registerd, true)}, nil
+	req.Gitleaks.GitleaksId = registerdGithubSetting.CodeGithubSettingID
+	registerdGitleaksSetting, err := c.repository.UpsertGitleaksSetting(ctx, req.Gitleaks)
+	if err != nil {
+		return nil, err
+	}
+	return &code.PutGitleaksResponse{Gitleaks: convertGitleaks(registerdGithubSetting, registerdGitleaksSetting, true)}, nil
 }
 
 func (c *CodeService) DeleteGitleaks(ctx context.Context, req *code.DeleteGitleaksRequest) (*empty.Empty, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := c.repository.DeleteGitleaks(ctx, req.ProjectId, req.GitleaksId)
+	err := c.repository.DeleteGithubSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		return nil, err
+	}
+	err = c.repository.DeleteGitleaksSetting(ctx, req.ProjectId, req.GitleaksId)
+	if err != nil {
+		return nil, err
+	}
+	organizations, err := c.repository.ListGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
+	if err != nil {
+		return nil, err
+	}
+	for _, org := range *organizations {
+		err = c.repository.DeleteGithubEnterpriseOrg(ctx, org.ProjectID, org.CodeGithubSettingID, org.Organization)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &empty.Empty{}, nil
 }
@@ -187,13 +207,13 @@ func getStatus(s string) code.Status {
 	}
 }
 
-func convertEnterpriseOrg(data *model.CodeEnterpriseOrg) *code.EnterpriseOrg {
+func convertEnterpriseOrg(data *model.CodeGithubEnterpriseOrg) *code.EnterpriseOrg {
 	if data == nil {
 		return &code.EnterpriseOrg{}
 	}
 	return &code.EnterpriseOrg{
-		GitleaksId: data.GitleaksID,
-		Login:      data.Login,
+		GitleaksId: data.CodeGithubSettingID,
+		Login:      data.Organization,
 		ProjectId:  data.ProjectID,
 		CreatedAt:  data.CreatedAt.Unix(),
 		UpdatedAt:  data.CreatedAt.Unix(),
@@ -204,7 +224,7 @@ func (c *CodeService) ListEnterpriseOrg(ctx context.Context, req *code.ListEnter
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	list, err := c.repository.ListEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
+	list, err := c.repository.ListGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &code.ListEnterpriseOrgResponse{}, nil
@@ -222,7 +242,7 @@ func (c *CodeService) PutEnterpriseOrg(ctx context.Context, req *code.PutEnterpr
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	registerd, err := c.repository.UpsertEnterpriseOrg(ctx, req.EnterpriseOrg)
+	registerd, err := c.repository.UpsertGithubEnterpriseOrg(ctx, req.EnterpriseOrg)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +253,7 @@ func (c *CodeService) DeleteEnterpriseOrg(ctx context.Context, req *code.DeleteE
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := c.repository.DeleteEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId, req.Login)
+	err := c.repository.DeleteGithubEnterpriseOrg(ctx, req.ProjectId, req.GitleaksId, req.Login)
 	if err != nil {
 		return nil, err
 	}
@@ -244,41 +264,29 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	data, err := c.repository.GetGitleaks(ctx, req.ProjectId, req.GitleaksId)
+	data, err := c.repository.GetGitleaksSetting(ctx, req.ProjectId, req.GitleaksId)
 	if err != nil {
 		return nil, err
 	}
 	resp, err := c.sqs.Send(ctx, c.sqs.CodeGitleaksQueueURL, &message.GitleaksQueueMessage{
-		GitleaksID: data.GitleaksID,
+		GitleaksID: data.CodeGithubSettingID,
 		ProjectID:  data.ProjectID,
 		ScanOnly:   req.ScanOnly,
 	})
 	if err != nil {
 		return nil, err
 	}
-	var scanSucceededAt int64
-	if data.ScanSucceededAt != nil {
-		scanSucceededAt = data.ScanSucceededAt.Unix()
-	}
-	if _, err = c.repository.UpsertGitleaks(ctx, &code.GitleaksForUpsert{
-		GitleaksId:        data.GitleaksID,
+	if _, err = c.repository.UpsertGitleaksSetting(ctx, &code.GitleaksForUpsert{
+		GitleaksId:        data.CodeGithubSettingID,
 		CodeDataSourceId:  data.CodeDataSourceID,
-		Name:              data.Name,
 		ProjectId:         data.ProjectID,
-		Type:              getType(data.Type),
-		BaseUrl:           data.BaseURL,
-		TargetResource:    data.TargetResource,
 		RepositoryPattern: data.RepositoryPattern,
-		GithubUser:        data.GithubUser,
-		// PersonalAccessToken :,
-		ScanPublic:      data.ScanPublic,
-		ScanInternal:    data.ScanInternal,
-		ScanPrivate:     data.ScanPrivate,
-		GitleaksConfig:  data.GitleaksConfig,
-		Status:          code.Status_IN_PROGRESS,
-		StatusDetail:    fmt.Sprintf("Start scan at %+v", time.Now().Format(time.RFC3339)),
-		ScanAt:          data.ScanAt.Unix(),
-		ScanSucceededAt: scanSucceededAt,
+		ScanPublic:        data.ScanPublic,
+		ScanInternal:      data.ScanInternal,
+		ScanPrivate:       data.ScanPrivate,
+		Status:            code.Status_IN_PROGRESS,
+		StatusDetail:      fmt.Sprintf("Start scan at %+v", time.Now().Format(time.RFC3339)),
+		ScanAt:            data.ScanAt.Unix(),
 	}); err != nil {
 		return nil, err
 	}
@@ -287,7 +295,7 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 }
 
 func (c *CodeService) InvokeScanAllGitleaks(ctx context.Context, _ *empty.Empty) (*empty.Empty, error) {
-	list, err := c.repository.ListGitleaks(ctx, 0, 0, 0)
+	list, err := c.repository.ListGitleaksSetting(ctx, 0)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &empty.Empty{}, nil
@@ -306,11 +314,11 @@ func (c *CodeService) InvokeScanAllGitleaks(ctx context.Context, _ *empty.Empty)
 			continue
 		}
 		if _, err := c.InvokeScanGitleaks(ctx, &code.InvokeScanGitleaksRequest{
-			GitleaksId: g.GitleaksID,
+			GitleaksId: g.CodeGithubSettingID,
 			ProjectId:  g.ProjectID,
 			ScanOnly:   true,
 		}); err != nil {
-			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: gitleaks_id=%d, err=%+v", g.GitleaksID, err)
+			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: code_github_setting_id=%d, err=%+v", g.CodeGithubSettingID, err)
 			return nil, err
 		}
 	}

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -90,8 +90,8 @@ func TestListGitleaks(t *testing.T) {
 		name                        string
 		input                       *code.ListGitleaksRequest
 		want                        *code.ListGitleaksResponse
-		mockGithubSettingResponse   *[]model.CodeGithubSetting
-		mockGithubSettingError      error
+		mockGitHubSettingResponse   *[]model.CodeGitHubSetting
+		mockGitHubSettingError      error
 		mockGitleaksSettingResponse *model.CodeGitleaksSetting
 		mockGitleaksSettingError    error
 		wantErr                     bool
@@ -103,26 +103,26 @@ func TestListGitleaks(t *testing.T) {
 				{GitleaksId: 1, CodeDataSourceId: 1, Name: "one", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: maskData, ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 				{GitleaksId: 2, CodeDataSourceId: 1, Name: "two", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: maskData, ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			}},
-			mockGithubSettingResponse: &[]model.CodeGithubSetting{
-				{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
-				{CodeGithubSettingID: 2, Name: "two", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			mockGitHubSettingResponse: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
+				{CodeGitHubSettingID: 2, Name: "two", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
 			},
 			mockGitleaksSettingResponse: &model.CodeGitleaksSetting{
-				CodeGithubSettingID: 1, CodeDataSourceID: 1, RepositoryPattern: "repo", ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, CodeDataSourceID: 1, RepositoryPattern: "repo", ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 		},
 		{
 			name:                      "OK empty",
 			input:                     &code.ListGitleaksRequest{ProjectId: 1, CodeDataSourceId: 1},
 			want:                      &code.ListGitleaksResponse{},
-			mockGithubSettingResponse: &[]model.CodeGithubSetting{},
-			mockGithubSettingError:    nil,
+			mockGitHubSettingResponse: &[]model.CodeGitHubSetting{},
+			mockGitHubSettingError:    nil,
 		},
 		{
 			name:  "NG gitleaks_setting not found",
 			input: &code.ListGitleaksRequest{ProjectId: 1, CodeDataSourceId: 1},
-			mockGithubSettingResponse: &[]model.CodeGithubSetting{
-				{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			mockGitHubSettingResponse: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
 			},
 			mockGitleaksSettingError: gorm.ErrRecordNotFound,
 			wantErr:                  true,
@@ -135,14 +135,14 @@ func TestListGitleaks(t *testing.T) {
 		{
 			name:                   "Invalid DB error",
 			input:                  &code.ListGitleaksRequest{ProjectId: 1, CodeDataSourceId: 1},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 		{
 			name:  "Invalid DB error (getGitleaks)",
 			input: &code.ListGitleaksRequest{ProjectId: 1, CodeDataSourceId: 1},
-			mockGithubSettingResponse: &[]model.CodeGithubSetting{
-				{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			mockGitHubSettingResponse: &[]model.CodeGitHubSetting{
+				{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
 			},
 			mockGitleaksSettingError: gorm.ErrInvalidDB,
 			wantErr:                  true,
@@ -150,11 +150,11 @@ func TestListGitleaks(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.mockGithubSettingResponse != nil || c.mockGithubSettingError != nil {
-				mockDB.On("ListGithubSetting").Return(c.mockGithubSettingResponse, c.mockGithubSettingError).Once()
+			if c.mockGitHubSettingResponse != nil || c.mockGitHubSettingError != nil {
+				mockDB.On("ListGitHubSetting").Return(c.mockGitHubSettingResponse, c.mockGitHubSettingError).Once()
 			}
 			if c.mockGitleaksSettingResponse != nil || c.mockGitleaksSettingError != nil {
-				times := len(*c.mockGithubSettingResponse)
+				times := len(*c.mockGitHubSettingResponse)
 				if c.mockGitleaksSettingError != nil {
 					times = 1
 				}
@@ -183,8 +183,8 @@ func TestGetGitleaks(t *testing.T) {
 		name                        string
 		input                       *code.GetGitleaksRequest
 		want                        *code.GetGitleaksResponse
-		mockGithubSettingResponse   *model.CodeGithubSetting
-		mockGithubSettingError      error
+		mockGitHubSettingResponse   *model.CodeGitHubSetting
+		mockGitHubSettingError      error
 		mockGitleaksSettingResponse *model.CodeGitleaksSetting
 		mockGitleaksSettingError    error
 		wantErr                     bool
@@ -193,14 +193,14 @@ func TestGetGitleaks(t *testing.T) {
 			name:                        "OK",
 			input:                       &code.GetGitleaksRequest{ProjectId: 1, GitleaksId: 1},
 			want:                        &code.GetGitleaksResponse{Gitleaks: &code.Gitleaks{GitleaksId: 1, CodeDataSourceId: 1, Name: "one", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: "token", ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
-			mockGithubSettingResponse:   &model.CodeGithubSetting{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
-			mockGitleaksSettingResponse: &model.CodeGitleaksSetting{CodeGithubSettingID: 1, CodeDataSourceID: 1, RepositoryPattern: "repo", ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGitHubSettingResponse:   &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
+			mockGitleaksSettingResponse: &model.CodeGitleaksSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, RepositoryPattern: "repo", ScanPublic: true, ScanInternal: false, ScanPrivate: false, Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now},
 		},
 		{
 			name:                   "OK empty",
 			input:                  &code.GetGitleaksRequest{ProjectId: 1, GitleaksId: 1},
 			want:                   &code.GetGitleaksResponse{},
-			mockGithubSettingError: gorm.ErrRecordNotFound,
+			mockGitHubSettingError: gorm.ErrRecordNotFound,
 		},
 		{
 			name:    "NG invalid param",
@@ -210,28 +210,28 @@ func TestGetGitleaks(t *testing.T) {
 		{
 			name:                      "NG not found gitleaks_setting",
 			input:                     &code.GetGitleaksRequest{ProjectId: 1},
-			mockGithubSettingResponse: &model.CodeGithubSetting{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			mockGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
 			mockGitleaksSettingError:  gorm.ErrRecordNotFound,
 			wantErr:                   true,
 		},
 		{
 			name:                   "Invalid DB error",
 			input:                  &code.GetGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 		{
 			name:                      "Invalid DB error (getGitleaks)",
 			input:                     &code.GetGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			mockGithubSettingResponse: &model.CodeGithubSetting{CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token"},
+			mockGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token"},
 			mockGitleaksSettingError:  gorm.ErrInvalidDB,
 			wantErr:                   true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.mockGithubSettingResponse != nil || c.mockGithubSettingError != nil {
-				mockDB.On("GetGithubSetting").Return(c.mockGithubSettingResponse, c.mockGithubSettingError).Once()
+			if c.mockGitHubSettingResponse != nil || c.mockGitHubSettingError != nil {
+				mockDB.On("GetGitHubSetting").Return(c.mockGitHubSettingResponse, c.mockGitHubSettingError).Once()
 			}
 			if c.mockGitleaksSettingResponse != nil || c.mockGitleaksSettingError != nil {
 				mockDB.On("GetGitleaksSetting").Return(c.mockGitleaksSettingResponse, c.mockGitleaksSettingError).Once()
@@ -265,8 +265,8 @@ func TestPutGitleaks(t *testing.T) {
 		name                        string
 		input                       *code.PutGitleaksRequest
 		want                        *code.PutGitleaksResponse
-		mockGithubSettingResponse   *model.CodeGithubSetting
-		mockGithubSettingError      error
+		mockGitHubSettingResponse   *model.CodeGitHubSetting
+		mockGitHubSettingError      error
 		mockGitleaksSettingResponse *model.CodeGitleaksSetting
 		mockGitleaksSettingError    error
 		wantErr                     bool
@@ -279,11 +279,11 @@ func TestPutGitleaks(t *testing.T) {
 			want: &code.PutGitleaksResponse{Gitleaks: &code.Gitleaks{
 				GitleaksId: 1, CodeDataSourceId: 1, Name: "one", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: maskData, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
-			mockGithubSettingResponse: &model.CodeGithubSetting{
-				CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token",
+			mockGitHubSettingResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token",
 			},
 			mockGitleaksSettingResponse: &model.CodeGitleaksSetting{
-				CodeGithubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, RepositoryPattern: "repo", Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, RepositoryPattern: "repo", Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 		},
 		{
@@ -294,11 +294,11 @@ func TestPutGitleaks(t *testing.T) {
 			want: &code.PutGitleaksResponse{Gitleaks: &code.Gitleaks{
 				GitleaksId: 1, CodeDataSourceId: 1, Name: "one", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: maskData, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix(), ScanSucceededAt: 0, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
-			mockGithubSettingResponse: &model.CodeGithubSetting{
-				CodeGithubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "token",
+			mockGitHubSettingResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ENTERPRISE", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token",
 			},
 			mockGitleaksSettingResponse: &model.CodeGitleaksSetting{
-				CodeGithubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, RepositoryPattern: "repo", Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, RepositoryPattern: "repo", Status: "OK", StatusDetail: "detail", ScanAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 		},
 		{
@@ -311,14 +311,14 @@ func TestPutGitleaks(t *testing.T) {
 			input: &code.PutGitleaksRequest{ProjectId: 1, Gitleaks: &code.GitleaksForUpsert{
 				GitleaksId: 1, CodeDataSourceId: 1, Name: "one", ProjectId: 1, Type: code.Type_ENTERPRISE, TargetResource: "target", RepositoryPattern: "repo", GithubUser: "user", PersonalAccessToken: maskData, Status: code.Status_OK, StatusDetail: "detail", ScanAt: now.Unix()},
 			},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.mockGithubSettingResponse != nil || c.mockGithubSettingError != nil {
-				mockDB.On("UpsertGithubSetting").Return(c.mockGithubSettingResponse, c.mockGithubSettingError).Once()
+			if c.mockGitHubSettingResponse != nil || c.mockGitHubSettingError != nil {
+				mockDB.On("UpsertGitHubSetting").Return(c.mockGitHubSettingResponse, c.mockGitHubSettingError).Once()
 			}
 			if c.mockGitleaksSettingResponse != nil || c.mockGitleaksSettingError != nil {
 				mockDB.On("UpsertGitleaksSetting").Return(c.mockGitleaksSettingResponse, c.mockGitleaksSettingError).Once()
@@ -345,11 +345,11 @@ func TestDeleteGitleaks(t *testing.T) {
 	cases := []struct {
 		name                               string
 		input                              *code.DeleteGitleaksRequest
-		isCalledDeleteGithubSetting        bool
-		mockGithubSettingError             error
+		isCalledDeleteGitHubSetting        bool
+		mockGitHubSettingError             error
 		isCalledDeleteGitleaksSetting      bool
 		mockGitleaksSettingError           error
-		mockListEnterpriseOrgResponse      *[]model.CodeGithubEnterpriseOrg
+		mockListEnterpriseOrgResponse      *[]model.CodeGitHubEnterpriseOrg
 		mockListEnterpriseOrgError         error
 		isCalledDeleteEnterpriseOrgSetting bool
 		mockDeleteEnterpriseOrgError       error
@@ -358,19 +358,19 @@ func TestDeleteGitleaks(t *testing.T) {
 		{
 			name:                          "OK",
 			input:                         &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting:   true,
+			isCalledDeleteGitHubSetting:   true,
 			isCalledDeleteGitleaksSetting: true,
-			mockListEnterpriseOrgResponse: &[]model.CodeGithubEnterpriseOrg{
-				{CodeGithubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+			mockListEnterpriseOrgResponse: &[]model.CodeGitHubEnterpriseOrg{
+				{CodeGitHubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
 			},
 			isCalledDeleteEnterpriseOrgSetting: true,
 		},
 		{
 			name:                          "OK (enterprise_org empty)",
 			input:                         &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting:   true,
+			isCalledDeleteGitHubSetting:   true,
 			isCalledDeleteGitleaksSetting: true,
-			mockListEnterpriseOrgResponse: &[]model.CodeGithubEnterpriseOrg{},
+			mockListEnterpriseOrgResponse: &[]model.CodeGitHubEnterpriseOrg{},
 		},
 		{
 			name:    "NG invalid param",
@@ -378,35 +378,35 @@ func TestDeleteGitleaks(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:                        "Invalid DB error (DeleteGithubSetting)",
+			name:                        "Invalid DB error (DeleteGitHubSetting)",
 			input:                       &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting: true,
-			mockGithubSettingError:      gorm.ErrInvalidDB,
+			isCalledDeleteGitHubSetting: true,
+			mockGitHubSettingError:      gorm.ErrInvalidDB,
 			wantErr:                     true,
 		},
 		{
 			name:                          "Invalid DB error (DeleteGitleaksSetting)",
 			input:                         &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting:   true,
+			isCalledDeleteGitHubSetting:   true,
 			isCalledDeleteGitleaksSetting: true,
 			mockGitleaksSettingError:      gorm.ErrInvalidDB,
 			wantErr:                       true,
 		},
 		{
-			name:                          "Invalid DB error (ListGithubEnterpriseOrg)",
+			name:                          "Invalid DB error (ListGitHubEnterpriseOrg)",
 			input:                         &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting:   true,
+			isCalledDeleteGitHubSetting:   true,
 			isCalledDeleteGitleaksSetting: true,
 			mockListEnterpriseOrgError:    gorm.ErrInvalidDB,
 			wantErr:                       true,
 		},
 		{
-			name:                          "Invalid DB error (DeleteGithubEnterpriseOrg)",
+			name:                          "Invalid DB error (DeleteGitHubEnterpriseOrg)",
 			input:                         &code.DeleteGitleaksRequest{ProjectId: 1, GitleaksId: 1},
-			isCalledDeleteGithubSetting:   true,
+			isCalledDeleteGitHubSetting:   true,
 			isCalledDeleteGitleaksSetting: true,
-			mockListEnterpriseOrgResponse: &[]model.CodeGithubEnterpriseOrg{
-				{CodeGithubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+			mockListEnterpriseOrgResponse: &[]model.CodeGitHubEnterpriseOrg{
+				{CodeGitHubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
 			},
 			isCalledDeleteEnterpriseOrgSetting: true,
 			mockDeleteEnterpriseOrgError:       gorm.ErrInvalidDB,
@@ -415,17 +415,17 @@ func TestDeleteGitleaks(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.isCalledDeleteGithubSetting {
-				mockDB.On("DeleteGithubSetting").Return(c.mockGithubSettingError).Once()
+			if c.isCalledDeleteGitHubSetting {
+				mockDB.On("DeleteGitHubSetting").Return(c.mockGitHubSettingError).Once()
 			}
 			if c.isCalledDeleteGitleaksSetting {
 				mockDB.On("DeleteGitleaksSetting").Return(c.mockGitleaksSettingError).Once()
 			}
 			if c.mockListEnterpriseOrgResponse != nil || c.mockListEnterpriseOrgError != nil {
-				mockDB.On("ListGithubEnterpriseOrg").Return(c.mockListEnterpriseOrgResponse, c.mockListEnterpriseOrgError).Once()
+				mockDB.On("ListGitHubEnterpriseOrg").Return(c.mockListEnterpriseOrgResponse, c.mockListEnterpriseOrgError).Once()
 			}
 			if c.isCalledDeleteEnterpriseOrgSetting {
-				mockDB.On("DeleteGithubEnterpriseOrg").Return(c.mockDeleteEnterpriseOrgError).Once()
+				mockDB.On("DeleteGitHubEnterpriseOrg").Return(c.mockDeleteEnterpriseOrgError).Once()
 			}
 			_, err := svc.DeleteGitleaks(ctx, c.input)
 			if !c.wantErr && err != nil {
@@ -444,8 +444,8 @@ func TestListEnterpriseOrg(t *testing.T) {
 		name                      string
 		input                     *code.ListEnterpriseOrgRequest
 		want                      *code.ListEnterpriseOrgResponse
-		mockGithubSettingResponse *[]model.CodeGithubEnterpriseOrg
-		mockGithubSettingError    error
+		mockGitHubSettingResponse *[]model.CodeGitHubEnterpriseOrg
+		mockGitHubSettingError    error
 		wantErr                   bool
 	}{
 		{
@@ -455,16 +455,16 @@ func TestListEnterpriseOrg(t *testing.T) {
 				{GitleaksId: 1, Login: "one", ProjectId: 1, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 				{GitleaksId: 2, Login: "two", ProjectId: 1, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			}},
-			mockGithubSettingResponse: &[]model.CodeGithubEnterpriseOrg{
-				{CodeGithubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
-				{CodeGithubSettingID: 2, Organization: "two", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+			mockGitHubSettingResponse: &[]model.CodeGitHubEnterpriseOrg{
+				{CodeGitHubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, Organization: "two", ProjectID: 1, CreatedAt: now, UpdatedAt: now},
 			},
 		},
 		{
 			name:                   "OK empty",
 			input:                  &code.ListEnterpriseOrgRequest{ProjectId: 1, GitleaksId: 1},
 			want:                   &code.ListEnterpriseOrgResponse{},
-			mockGithubSettingError: gorm.ErrRecordNotFound,
+			mockGitHubSettingError: gorm.ErrRecordNotFound,
 		},
 		{
 			name:    "NG invalid param",
@@ -474,14 +474,14 @@ func TestListEnterpriseOrg(t *testing.T) {
 		{
 			name:                   "Invalid DB error",
 			input:                  &code.ListEnterpriseOrgRequest{ProjectId: 1, GitleaksId: 1},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.mockGithubSettingResponse != nil || c.mockGithubSettingError != nil {
-				mockDB.On("ListGithubEnterpriseOrg").Return(c.mockGithubSettingResponse, c.mockGithubSettingError).Once()
+			if c.mockGitHubSettingResponse != nil || c.mockGitHubSettingError != nil {
+				mockDB.On("ListGitHubEnterpriseOrg").Return(c.mockGitHubSettingResponse, c.mockGitHubSettingError).Once()
 			}
 			got, err := svc.ListEnterpriseOrg(ctx, c.input)
 			if !c.wantErr && err != nil {
@@ -506,8 +506,8 @@ func TestPutEnterpriseOrg(t *testing.T) {
 		name                      string
 		input                     *code.PutEnterpriseOrgRequest
 		want                      *code.PutEnterpriseOrgResponse
-		mockGithubSettingResponse *model.CodeGithubEnterpriseOrg
-		mockGithubSettingError    error
+		mockGitHubSettingResponse *model.CodeGitHubEnterpriseOrg
+		mockGitHubSettingError    error
 		wantErr                   bool
 	}{
 		{
@@ -518,8 +518,8 @@ func TestPutEnterpriseOrg(t *testing.T) {
 			want: &code.PutEnterpriseOrgResponse{EnterpriseOrg: &code.EnterpriseOrg{
 				GitleaksId: 1, Login: "one", ProjectId: 1, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
-			mockGithubSettingResponse: &model.CodeGithubEnterpriseOrg{
-				CodeGithubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now,
+			mockGitHubSettingResponse: &model.CodeGitHubEnterpriseOrg{
+				CodeGitHubSettingID: 1, Organization: "one", ProjectID: 1, CreatedAt: now, UpdatedAt: now,
 			},
 		},
 		{
@@ -532,14 +532,14 @@ func TestPutEnterpriseOrg(t *testing.T) {
 			input: &code.PutEnterpriseOrgRequest{ProjectId: 1, EnterpriseOrg: &code.EnterpriseOrgForUpsert{
 				GitleaksId: 1, Login: "one", ProjectId: 1},
 			},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.mockGithubSettingResponse != nil || c.mockGithubSettingError != nil {
-				mockDB.On("UpsertGithubEnterpriseOrg").Return(c.mockGithubSettingResponse, c.mockGithubSettingError).Once()
+			if c.mockGitHubSettingResponse != nil || c.mockGitHubSettingError != nil {
+				mockDB.On("UpsertGitHubEnterpriseOrg").Return(c.mockGitHubSettingResponse, c.mockGitHubSettingError).Once()
 			}
 			got, err := svc.PutEnterpriseOrg(ctx, c.input)
 			if !c.wantErr && err != nil {
@@ -562,7 +562,7 @@ func TestDeleteEnterpriseOrg(t *testing.T) {
 	cases := []struct {
 		name                   string
 		input                  *code.DeleteEnterpriseOrgRequest
-		mockGithubSettingError error
+		mockGitHubSettingError error
 		wantErr                bool
 	}{
 		{
@@ -577,13 +577,13 @@ func TestDeleteEnterpriseOrg(t *testing.T) {
 		{
 			name:                   "Invalid DB error",
 			input:                  &code.DeleteEnterpriseOrgRequest{ProjectId: 1, GitleaksId: 1, Login: "login"},
-			mockGithubSettingError: gorm.ErrInvalidDB,
+			mockGitHubSettingError: gorm.ErrInvalidDB,
 			wantErr:                true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			mockDB.On("DeleteGithubEnterpriseOrg").Return(c.mockGithubSettingError).Once()
+			mockDB.On("DeleteGitHubEnterpriseOrg").Return(c.mockGitHubSettingError).Once()
 			_, err := svc.DeleteEnterpriseOrg(ctx, c.input)
 			if !c.wantErr && err != nil {
 				t.Fatalf("Unexpected error occured: %+v", err)


### PR DESCRIPTION
新しいEntityに移行するためのmodel,dbとserverのコード修正
- model
CodeGitleaksモデルをCodeGithubSetting,CodeGitleaksSettingに分割
元々CodeGitleaksに存在していたフィールドは以下に分割されます
  - CodeGithubSetting
    - CodeGithubSettingID (CodeGitleaksのGitleaksID)
    - Name
    - ProjectID
    - Type
    - BaseURL
    - TargetResource
    - GithubUser
    - PersonalAccessToken
    - CreatedAt
    - UpdatedAt
  - CodeGitleaksSetting
    - CodeGithubSettingID (CodeGitleaksのGitleaksID、親のCodeGithubSettingと同値にする)
    - CodeDataSourceID
    - ProjectID
    - RepositoryPattern
    - ScanPublic
    - ScanInternal
    - ScanPrivate
    - Status
    - StatusDetail
    - ScanAt
    - CreatedAt
    - UpdatedAt

CodeEnterpriseOrgモデルはCodeGithubEnterpriseOrgに命名変更します
また、フィールドLoginをOrganizationに名前の変更を行います

以下の２パラメータは現状使用されていないため、廃止します(gRPCのレスポンスとしてはゼロ値が返されるようになります)
- GitleaksConfig
- ScanSucceededAt

- DB
modelの修正に合わせて、code_github_setting,code_gitleaks_setting,code_github_enterprise_orgの操作を行うメソッドの追加

- server
Gitleaks関連のServiceは元々1つのテーブルを操作ところが、2つのテーブルを操作するようになったため以下のような挙動へと変更しています。
- ListGitleaks,GetGitleaks
GithubSetting取得後、取得したGithubSettingのIDからGitleaksSettingを取得
2つのデータからレスポンスを作成します
GithubSettingとGitleaksSettingは1:1の関係になるため、取得したGithubSettingのIDを持つGitleaksSettingが存在しない場合エラーを返します
- PutGitleaks
リクエストデータから上記モデルの通りにデータを分割して登録します
- DeleteGitleaks
リクエストデータからCodeGithubSettingを削除
その後、削除したデータを親に持つCodeGitleaksSetting,CodeGithubEnterpriseOrgを削除

- GithubEnterpriseOrg
テーブル(モデル)名の変更とパラメータ名LoginをOrganizationへの変更を行いました