### PR TITLE
Return error when failed to create db.NewClient

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,10 @@ func main() {
 		LogMode:        conf.DBLogMode,
 		MaxConnection:  conf.DBMaxConnection,
 	}
-	d := db.NewClient(dbConf, logger)
+	d, err := db.NewClient(dbConf, logger)
+	if err != nil {
+		logger.Fatalf(ctx, "failed to create database client: %w", err)
+	}
 	queueConf := &queue.SQSConfig{
 		AWSRegion:   conf.AWSRegion,
 		SQSEndpoint: conf.SQSEndpoint,

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -17,25 +17,25 @@ type Client struct {
 	logger   logging.Logger
 }
 
-func NewClient(conf *Config, l logging.Logger) *Client {
+func NewClient(conf *Config, l logging.Logger) (*Client, error) {
 	ctx := context.Background()
 	m, err := connect(conf, true)
 	if err != nil {
-		l.Fatalf(ctx, "failed to connect database: %w", err)
+		return nil, fmt.Errorf("failed to connect database of master: %w", err)
 	}
-	l.Infof(ctx, "Connected to Database. isMaster: %t", true)
+	l.Info(ctx, "Connected to Database of master.")
 
 	s, err := connect(conf, false)
 	if err != nil {
-		l.Fatalf(ctx, "failed to connect database: %w", err)
+		return nil, fmt.Errorf("failed to connect database of slave: %w", err)
 	}
-	l.Infof(ctx, "Connected to Database. isMaster: %t", false)
+	l.Info(ctx, "Connected to Database of slave.")
 
 	return &Client{
 		MasterDB: m,
 		SlaveDB:  s,
 		logger:   l,
-	}
+	}, nil
 }
 
 type Config struct {


### PR DESCRIPTION
pkg/db配下のfunctionで、発生したerrorを呼び出し元に返していなかったものがあったので呼び出し元に返すよう変更。
db.NewClientは、function内でexitするのではなくmainでexitするためにerrorを返すようにしました。