### PR TITLE
Return error when failed to create queue.NewClient

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,10 @@ func main() {
 		DiagnosisPortscanQueueURL:        conf.DiagnosisPortscanQueueURL,
 		DiagnosisApplicationScanQueueURL: conf.DiagnosisApplicationScanQueueURL,
 	}
-	q := queue.NewSQSClient(ctx, queueConf, logger)
+	q, err := queue.NewClient(queueConf, logger)
+	if err != nil {
+		logger.Fatalf(ctx, "failed to create sqs client: %w", err)
+	}
 	s := server.NewServer(
 		conf.Port,
 		conf.CoreSvcAddr,

--- a/pkg/queue/sqs.go
+++ b/pkg/queue/sqs.go
@@ -71,12 +71,12 @@ type Client struct {
 	DiagnosisApplicationScanQueueURL string
 }
 
-func NewSQSClient(ctx context.Context, conf *SQSConfig, l logging.Logger) *Client {
+func NewClient(conf *SQSConfig, l logging.Logger) (*Client, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {
-		l.Fatalf(ctx, "Failed to create sqs session, err=%w", err)
+		return nil, fmt.Errorf("failed to create sqs session, err=%w", err)
 	}
 	sqsClient := sqs.New(sess, &aws.Config{
 		Region:   &conf.AWSRegion,
@@ -101,7 +101,7 @@ func NewSQSClient(ctx context.Context, conf *SQSConfig, l logging.Logger) *Clien
 		DiagnosisWpscanQueueURL:          conf.DiagnosisWpscanQueueURL,
 		DiagnosisPortscanQueueURL:        conf.DiagnosisPortscanQueueURL,
 		DiagnosisApplicationScanQueueURL: conf.DiagnosisApplicationScanQueueURL,
-	}
+	}, nil
 }
 
 func (c *Client) Send(ctx context.Context, url string, msg interface{}) (*sqs.SendMessageOutput, error) {


### PR DESCRIPTION
pkg/queue配下のfunctionで、発生したerrorを呼び出し元に返していなかったものがあったので呼び出し元に返すよう変更。
queue.NewClientは、function内でexitするのではなくmainでexitするためにerrorを返すようにしました。