### PR TITLE
Fix error handling in pkg/server

### DIFF
--- a/pkg/server/code/service.go
+++ b/pkg/server/code/service.go
@@ -1,9 +1,9 @@
 package code
 
 import (
-	"context"
 	"crypto/aes"
 	"crypto/cipher"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/proto/project"
@@ -20,12 +20,11 @@ type CodeService struct {
 	logger        logging.Logger
 }
 
-func NewCodeService(coreSvcAddr, dataKey string, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, l logging.Logger) code.CodeServiceServer {
-	ctx := context.Background()
+func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, l logging.Logger) (code.CodeServiceServer, error) {
 	key := []byte(dataKey)
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		l.Fatal(ctx, err.Error())
+		return nil, fmt.Errorf("failed to create cipher, err=%w", err)
 	}
 	return &CodeService{
 		repository:    repo,
@@ -33,5 +32,5 @@ func NewCodeService(coreSvcAddr, dataKey string, repo db.CodeRepoInterface, q *q
 		cipherBlock:   block,
 		projectClient: pj,
 		logger:        l,
-	}
+	}, nil
 }

--- a/pkg/server/diagnosis/diagnosis.go
+++ b/pkg/server/diagnosis/diagnosis.go
@@ -164,16 +164,12 @@ func (d *DiagnosisService) InvokeScan(ctx context.Context, req *diagnosis.Invoke
 			return nil, err
 		}
 		for _, target := range *portscanTargets {
-			msg, err := makePortscanMessage(data.ProjectID, data.PortscanSettingID, target.PortscanTargetID, target.Target)
-			if err != nil {
-				d.logger.Errorf(ctx, "Error occured when making Portscan message, error: %v", err)
-				continue
-			}
+			msg := makePortscanMessage(data.ProjectID, data.PortscanSettingID, target.PortscanTargetID, target.Target)
 			msg.ScanOnly = req.ScanOnly
 			resp, err = d.sqs.Send(ctx, d.sqs.DiagnosisPortscanQueueURL, msg)
 			if err != nil {
 				d.logger.Errorf(ctx, "Error occured when sending Portscan message, error: %v", err)
-				continue
+				return nil, err
 			}
 			var scanAt time.Time
 			if !zero.IsZeroVal(target.ScanAt) {

--- a/pkg/server/diagnosis/portscan.go
+++ b/pkg/server/diagnosis/portscan.go
@@ -189,7 +189,7 @@ func convertPortscanTarget(data *model.PortscanTarget) *diagnosis.PortscanTarget
 	}
 }
 
-func makePortscanMessage(projectID, settingID, portscanTargetID uint32, target string) (*message.PortscanQueueMessage, error) {
+func makePortscanMessage(projectID, settingID, portscanTargetID uint32, target string) *message.PortscanQueueMessage {
 	msg := &message.PortscanQueueMessage{
 		DataSource:        message.DataSourceNamePortScan,
 		PortscanSettingID: settingID,
@@ -197,5 +197,5 @@ func makePortscanMessage(projectID, settingID, portscanTargetID uint32, target s
 		ProjectID:         projectID,
 		Target:            target,
 	}
-	return msg, nil
+	return msg
 }

--- a/pkg/server/google/resourcemanager.go
+++ b/pkg/server/google/resourcemanager.go
@@ -20,21 +20,20 @@ type ResourceManagerClient struct {
 	svc    *cloudresourcemanager.Service
 }
 
-func newResourceManagerClient(credentialPath string, logger logging.Logger) ResourceManagerServiceClient {
-	ctx := context.Background()
+func newResourceManagerClient(ctx context.Context, credentialPath string, logger logging.Logger) (ResourceManagerServiceClient, error) {
 	svc, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
-		logger.Fatalf(ctx, "Failed to create new Cloud Resource Manager service: %w", err)
+		return nil, fmt.Errorf("failed to create new Cloud Resource Manager service: err=%w", err)
 	}
 
 	// Remove credential file for Security
 	if err := os.Remove(credentialPath); err != nil {
-		logger.Fatalf(ctx, "Failed to remove file: path=%s, err=%w", credentialPath, err)
+		return nil, fmt.Errorf("failed to remove file: path=%s, err=%w", credentialPath, err)
 	}
 	return &ResourceManagerClient{
 		svc:    svc,
 		logger: logger,
-	}
+	}, nil
 }
 
 const (

--- a/pkg/server/google/service.go
+++ b/pkg/server/google/service.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"context"
+	"fmt"
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/proto/project"
 	"github.com/ca-risken/datasource-api/pkg/db"
@@ -15,13 +17,16 @@ type GoogleService struct {
 	logger          logging.Logger
 }
 
-func NewGoogleService(credentialPath string, repo db.GoogleRepoInterface, q *queue.Client, pj project.ProjectServiceClient, l logging.Logger) *GoogleService {
-	r := newResourceManagerClient(credentialPath, l)
+func NewGoogleService(ctx context.Context, credentialPath string, repo db.GoogleRepoInterface, q *queue.Client, pj project.ProjectServiceClient, l logging.Logger) (*GoogleService, error) {
+	r, err := newResourceManagerClient(ctx, credentialPath, l)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource manager client: err=%w", err)
+	}
 	return &GoogleService{
 		repository:      repo,
 		sqs:             q,
 		resourceManager: r,
 		projectClient:   pj,
 		logger:          l,
-	}
+	}, nil
 }


### PR DESCRIPTION
pkg/server配下のfunctionで、発生したerrorを呼び出し元に返していなかったものがあったので呼び出し元に返すよう変更。
client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
また、不要なエラーを削除しました。