### PR TITLE
fix getGitleaksSetting

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -178,7 +178,7 @@ func (c *Client) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]
 
 func (c *Client) GetGitleaksSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*model.CodeGitleaksSetting, error) {
 	var data model.CodeGitleaksSetting
-	if err := c.SlaveDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&data).Error; err != nil {
+	if err := c.MasterDB.WithContext(ctx).Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil


### PR DESCRIPTION
GitleaksSetting登録時に、登録した値をレスポンスとして返却するためにGetGitleaksSettingを実行しますが、
MasterでのInsert後、SlaveにてGet処理を実行するとrecord not foundが発生しました。
対策として、Get処理をMasterDBで実行するように修正します。

以下のタイミングで、GetGitleaksを実行します
- GitleaksSettingの更新/登録時
- Gitleaksデータソースのスキャン実行時
短時間で大量に呼び出されることがないと判断したため、Masterへの負荷に影響はないと考えます。