### PR TITLE
fix code db

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -166,9 +166,12 @@ func (c *Client) DeleteGitHubSetting(ctx context.Context, projectID uint32, gith
 }
 
 func (c *Client) ListGitleaksSetting(ctx context.Context, projectID uint32) (*[]model.CodeGitleaksSetting, error) {
-	query := `select * from code_gitleaks_setting where project_id = ?`
+	query := `select * from code_gitleaks_setting`
 	var params []interface{}
-	params = append(params, projectID)
+	if !zero.IsZeroVal(projectID) {
+		query += " where project_id = ?"
+		params = append(params, projectID)
+	}
 	data := []model.CodeGitleaksSetting{}
 	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -342,6 +342,21 @@ func TestListGitleaksSetting(t *testing.T) {
 			},
 		},
 		{
+			name: "OK project_id 0 value",
+			args: args{ProjectID: 0},
+			want: &[]model.CodeGitleaksSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: true, ScanInternal: true, ScanPrivate: true, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+				{CodeGitHubSettingID: 2, CodeDataSourceID: 1, ProjectID: 1, ScanPublic: false, ScanInternal: true, ScanPrivate: false, Status: "OK", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("select * from code_gitleaks_setting")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "code_data_source_id", "project_id", "scan_public", "scan_internal", "scan_private", "status", "scan_at", "created_at", "updated_at"}).
+					AddRow(uint32(1), uint32(1), uint32(1), true, true, true, "OK", now, now, now).
+					AddRow(uint32(2), uint32(1), uint32(1), false, true, false, "OK", now, now, now))
+			},
+		},
+		{
 			name:    "NG DB error",
 			args:    args{ProjectID: 1},
 			want:    nil,


### PR DESCRIPTION
ListGitleaksSettingで、project_idの値が0値の場合に検索条件に含めない修正を加えます
この関数はサービスのListGitleaks,InvokeScanAllメソッドから呼ばれますが、
ListGitleaksから呼び出される場合、必ずproject_idの値が含まれる(validationで0値を弾くため)
InvokeScanAllから呼び出される場合、必ず0値で呼び出されます