### PR TITLE
Fix-code-queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .perman-aws-vault
 .idea/
+.vscode/

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -317,7 +317,7 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.sqs.Send(ctx, c.sqs.CodeGitleaksQueueURL, &message.CodeQueueMessage{
+	resp, err := c.sqs.Send(ctx, c.codeGitleaksQueueURL, &message.CodeQueueMessage{
 		GitHubSettingID: data.CodeGitHubSettingID,
 		ProjectID:       data.ProjectID,
 		ScanOnly:        req.ScanOnly,


### PR DESCRIPTION
CodeServiceで持つsqsをqueue.Clientからインターフェースへ変更します
queue.Clientから変更したことによりQueueURLが参照できなくなったため、これも値として持つように修正します
(InvokeScanのテストが行いにくいことを改善するため)

CodeQueueURLの渡し方がこれでいいのかちょっと迷ってます。良い方法あればご教示いただきたいです。