### PR TITLE
fix: aws scan message

### DIFF
--- a/pkg/message/aws.go
+++ b/pkg/message/aws.go
@@ -29,6 +29,7 @@ type AWSQueueMessage struct {
 	AssumeRoleArn   string `json:"assume_role_arn"`
 	ExternalID      string `json:"external_id"`
 	ScanOnly        bool   `json:"scan_only,string"`
+	SpecificVersion string `json:"specific_version"`
 }
 
 // Validate is the validation to GuardDutyMessage

--- a/pkg/server/aws/aws.go
+++ b/pkg/server/aws/aws.go
@@ -190,6 +190,7 @@ func (a *AWSService) InvokeScan(ctx context.Context, req *aws.InvokeScanRequest)
 		AssumeRoleArn:   ds.AssumeRoleArn,
 		ExternalID:      ds.ExternalID,
 		ScanOnly:        req.ScanOnly,
+		SpecificVersion: ds.SpecificVersion,
 	}
 	var resp *sqs.SendMessageOutput
 	if msg.DataSource == message.AWSAccessAnalyzerDataSource {


### PR DESCRIPTION
datasource側で利用するためversion情報をキューメッセージに追加します