### PR TITLE
refactor: analyzer interface

### DIFF
--- a/pkg/attackflow/attack_flow.go
+++ b/pkg/attackflow/attack_flow.go
@@ -2,6 +2,7 @@ package attackflow
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/datasource-api/proto/datasource"
 )
@@ -17,8 +18,42 @@ const (
 
 	// common resource
 	RESOURCE_INTERNET = "Internet"
+
+	// hard limit
+	MAX_ANALYZE_NUM = 100
 )
 
-type AttackFlowAnalyzer interface {
-	Analyze(ctx context.Context, req *datasource.AnalyzeAttackFlowRequest) (*datasource.AnalyzeAttackFlowResponse, error)
+type CSP interface {
+	GetInitialServiceAnalyzer(ctx context.Context, req *datasource.AnalyzeAttackFlowRequest) (CloudServiceAnalyzer, error)
+}
+
+type CloudServiceAnalyzer interface {
+	Analyze(ctx context.Context, resp *datasource.AnalyzeAttackFlowResponse) (*datasource.AnalyzeAttackFlowResponse, error)
+	Next(ctx context.Context, resp *datasource.AnalyzeAttackFlowResponse) (*datasource.AnalyzeAttackFlowResponse, []CloudServiceAnalyzer, error)
+}
+
+func existsInternetNode(nodes []*datasource.Resource) bool {
+	for _, node := range nodes {
+		if node.ResourceName == RESOURCE_INTERNET {
+			return true
+		}
+	}
+	return false
+}
+
+func getInternetNode() *datasource.Resource {
+	return &datasource.Resource{
+		ResourceName: RESOURCE_INTERNET,
+		ShortName:    RESOURCE_INTERNET,
+		Layer:        LAYER_INTERNET,
+	}
+}
+
+func getEdge(source, target, edgeLabel string) *datasource.ResourceRelationship {
+	return &datasource.ResourceRelationship{
+		RelationId:         fmt.Sprintf("ed-[%s]-[%s]", source, target),
+		SourceResourceName: source,
+		TargetResourceName: target,
+		RelationLabel:      edgeLabel,
+	}
 }

--- a/pkg/server/datasource/service.go
+++ b/pkg/server/datasource/service.go
@@ -65,7 +65,7 @@ func (d *DataSourceService) AnalyzeAttackFlow(ctx context.Context, req *datasour
 	for {
 		resp, err = serviceAnalyzer.Analyze(ctx, resp)
 		if err != nil {
-			return nil, err
+			return nil, status.Errorf(codes.Internal, "failed to analyze attack flow: %s", err.Error())
 		}
 		var next []attackflow.CloudServiceAnalyzer
 		resp, next, err = serviceAnalyzer.Next(ctx, resp)


### PR DESCRIPTION
今後サポート対象のサービスを追加していく前にリファクタしておきます。（動作としては変わりません）

- `AttackFlowAnalyzer` というインターフェースをCSPごとに用意していましたが以下の2つに分割します
  - `CSP`
  - `CloudServiceAnalyzer`
- `CSP` インターフェースはAWSやGoogleCloudなどの単位で実装します
  - GetInitialServiceAnalyzer: 最初の解析対象のCloudServiceAnalyzerを返却します
- `CloudServiceAnalyzer`インターフェースはサービスごとに実装します
  - Analyze: 対象サービスの解析を行います
  - Next: バックエンドサービスが存在する場合は次のCloudServiceAnalyzerを返却します

今後、例えばALB、Lambda、EC2、IAMとかを追加する場合にはサービスごとにCloudServiceAnalyzerを実装しサポート対象に追加するイメージです