### PR TITLE
fix: attack-flow meta

### DIFF
--- a/pkg/attackflow/attack_flow.go
+++ b/pkg/attackflow/attack_flow.go
@@ -46,6 +46,7 @@ func getInternetNode() *datasource.Resource {
 		ResourceName: RESOURCE_INTERNET,
 		ShortName:    RESOURCE_INTERNET,
 		Layer:        LAYER_INTERNET,
+		Service:      "internet",
 	}
 }
 

--- a/pkg/attackflow/aws_cloudfront.go
+++ b/pkg/attackflow/aws_cloudfront.go
@@ -119,7 +119,7 @@ func (c *cloudFrontAnalyzer) Next(ctx context.Context, resp *datasource.AnalyzeA
 		switch awsService {
 		case SERVICE_S3:
 			s3ARN := getS3ARNFromDomain(origin)
-			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, s3ARN, origin))
+			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, s3ARN, "origin"))
 			s3Analyzer, err := newS3Analyzer(s3ARN, c.awsConfig, c.logger)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
edgeのラベルが長すぎて描画の見栄えが悪いので短くします。
また、共通項目であるサービスプロパティが抜けていたので修正します。