### PR TITLE
Add service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/ca-risken/common/pkg/rpc v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/core v0.3.1-0.20220725072737-99d976980d0f
+	github.com/coocood/freecache v1.2.3
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/confluentinc/confluent-kafka-go v1.4.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/coocood/freecache v1.2.3 h1:lcBwpZrwBZRZyLk/8EMyQVXRiFl663cCuMOrjCALeto=
+github.com/coocood/freecache v1.2.3/go.mod h1:RBUWa/Cy+OHdfTGFEhEuE1pMCMX51Ncizj7rthiQ3vk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=

--- a/pkg/attackflow/aws.go
+++ b/pkg/attackflow/aws.go
@@ -44,6 +44,8 @@ var (
 	domainPatternS3         = regexp.MustCompile(`\.s3\..*\.amazonaws\.com$`)  // https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/userguide/VirtualHosting.html
 	domainPatternLambdaURL  = regexp.MustCompile(`\.lambda-url\..*\.on\.aws$`) // https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html
 	domainPatternELB        = regexp.MustCompile(`(\.elb\.amazonaws\.com$|\.elb\..*\.amazonaws\.com$)`)
+	domainPatternELB1       = regexp.MustCompile(`\.elb\.amazonaws\.com$`)
+	domainPatternELB2       = regexp.MustCompile(`\.elb\..*\.amazonaws\.com$`)
 	domainPatternAPIGateway = regexp.MustCompile(`\.execute-api\..*\.amazonaws\.com$`)
 	domainPatternEC2        = regexp.MustCompile(`^ec2-.*\.compute\.amazonaws\.com$`)
 

--- a/pkg/attackflow/aws_api_gateway_v2.go
+++ b/pkg/attackflow/aws_api_gateway_v2.go
@@ -87,3 +87,18 @@ func (a *apiGatewayAnalyzer) analyzeV2(ctx context.Context, resp *datasource.Ana
 	resp = setNode(a.metadata.IsPublic, "api", a.resource, resp)
 	return resp, nil
 }
+
+func isV2ApiID(ctx context.Context, apiID string, cfg *aws.Config) (bool, error) {
+	client := apigatewayv2.NewFromConfig(*cfg)
+	// https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid.html
+	apis, err := client.GetApis(ctx, &apigatewayv2.GetApisInput{})
+	if err != nil {
+		return false, err
+	}
+	for _, api := range apis.Items {
+		if aws.ToString(api.ApiId) == apiID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/attackflow/aws_cloudfront.go
+++ b/pkg/attackflow/aws_cloudfront.go
@@ -141,6 +141,18 @@ func (c *cloudFrontAnalyzer) Next(ctx context.Context, resp *datasource.AnalyzeA
 			}
 			analyzers = append(analyzers, elbAnalyzer)
 			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, elbARN, "origin"))
+		case SERVICE_API_GATEWAY:
+			apiGatewayARN, err := getAPIGatewayARNFromPublicDomain(ctx, o.DomainName, c.resource.CloudId, c.awsConfig)
+			if err != nil {
+				c.logger.Warnf(ctx, "failed to get api gateway ARN from public domain: %s", err)
+				continue
+			}
+			apiGatewayAnalyzer, err := newAPIGatewayAnalyzer(ctx, apiGatewayARN, c.awsConfig, c.logger)
+			if err != nil {
+				return nil, nil, err
+			}
+			analyzers = append(analyzers, apiGatewayAnalyzer)
+			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, apiGatewayARN, "origin"))
 		default:
 			c.logger.Warnf(ctx, "unsupported aws service: %s", awsService)
 			c.setCustomDomain(o, resp)

--- a/pkg/attackflow/aws_cloudfront.go
+++ b/pkg/attackflow/aws_cloudfront.go
@@ -129,6 +129,18 @@ func (c *cloudFrontAnalyzer) Next(ctx context.Context, resp *datasource.AnalyzeA
 			}
 			analyzers = append(analyzers, ec2Analyzer)
 			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, ec2ARN, "origin"))
+		case SERVICE_ELB:
+			elbARN, err := getElbARNFromPublicDomain(ctx, o.DomainName, c.resource.CloudId, c.awsConfig)
+			if err != nil {
+				c.logger.Warnf(ctx, "failed to get elb ARN from public domain: %s", err)
+				continue
+			}
+			elbAnalyzer, err := newELBAnalyzer(ctx, elbARN, c.awsConfig, c.logger)
+			if err != nil {
+				return nil, nil, err
+			}
+			analyzers = append(analyzers, elbAnalyzer)
+			resp.Edges = append(resp.Edges, getEdge(c.resource.ResourceName, elbARN, "origin"))
 		default:
 			c.logger.Warnf(ctx, "unsupported aws service: %s", awsService)
 			c.setCustomDomain(o, resp)

--- a/pkg/attackflow/aws_elb_v2.go
+++ b/pkg/attackflow/aws_elb_v2.go
@@ -81,3 +81,18 @@ func (e *elbAnalyzer) analyzeV2(ctx context.Context, resp *datasource.AnalyzeAtt
 	resp = setNode(e.metadata.IsPublic, "", e.resource, resp)
 	return resp, nil
 }
+
+func searchElbDomainV2(ctx context.Context, domain string, cfg *aws.Config) (string, error) {
+	client := elasticloadbalancingv2.NewFromConfig(*cfg)
+	// https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html
+	lb, err := client.DescribeLoadBalancers(ctx, &elasticloadbalancingv2.DescribeLoadBalancersInput{})
+	if err != nil {
+		return "", err
+	}
+	for _, l := range lb.LoadBalancers {
+		if aws.ToString(l.DNSName) == domain {
+			return aws.ToString(l.LoadBalancerArn), nil
+		}
+	}
+	return "", nil
+}

--- a/pkg/attackflow/aws_iam.go
+++ b/pkg/attackflow/aws_iam.go
@@ -40,6 +40,18 @@ func newIAMAnalyzer(arn string, cfg *aws.Config, logger logging.Logger) (CloudSe
 func (i *iamAnalyzer) Analyze(ctx context.Context, resp *datasource.AnalyzeAttackFlowResponse) (
 	*datasource.AnalyzeAttackFlowResponse, error,
 ) {
+	// cache
+	cachedResource, cachedMeta, err := getIAMRunnerAttackFlowCache(i.resource.CloudId, i.resource.ResourceName)
+	if err != nil {
+		return nil, err
+	}
+	if cachedResource != nil && cachedMeta != nil {
+		i.resource = cachedResource
+		i.metadata = cachedMeta
+		resp = setNode(false, "", cachedResource, resp)
+		return resp, nil
+	}
+
 	i.metadata.IamRoleArn = i.resource.ResourceName
 	// instance-profile
 	if strings.HasPrefix(i.resource.ResourceName, fmt.Sprintf("arn:aws:iam::%s:instance-profile/", i.resource.CloudId)) {
@@ -73,6 +85,11 @@ func (i *iamAnalyzer) Analyze(ctx context.Context, resp *datasource.AnalyzeAttac
 		return nil, err
 	}
 	resp = setNode(false, "", i.resource, resp)
+
+	// cache
+	if err := setAttackFlowCache(i.resource.CloudId, i.resource.ResourceName, i.resource); err != nil {
+		return nil, err
+	}
 	return resp, nil
 }
 

--- a/pkg/attackflow/aws_iam.go
+++ b/pkg/attackflow/aws_iam.go
@@ -41,7 +41,7 @@ func (i *iamAnalyzer) Analyze(ctx context.Context, resp *datasource.AnalyzeAttac
 	*datasource.AnalyzeAttackFlowResponse, error,
 ) {
 	// cache
-	cachedResource, cachedMeta, err := getIAMRunnerAttackFlowCache(i.resource.CloudId, i.resource.ResourceName)
+	cachedResource, cachedMeta, err := getIAMAttackFlowCache(i.resource.CloudId, i.resource.ResourceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/attackflow/cache.go
+++ b/pkg/attackflow/cache.go
@@ -1,0 +1,128 @@
+package attackflow
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ca-risken/datasource-api/proto/datasource"
+	"github.com/coocood/freecache"
+)
+
+const (
+	ATTACK_FLOW_CACHE_SIZE       = 10 * 1024 * 1024 // 10MB
+	ATTACK_FLOW_CACHE_EXPIRE_SEC = 3600
+	ATTACK_FLOW_CACHE_KEY_FORMAT = "attack-flow/%s/%s"
+)
+
+// local cache for attack flow
+var attackFlowCache = freecache.NewCache(ATTACK_FLOW_CACHE_SIZE)
+
+func generateCacheKey(cloudID, resourceName string) []byte {
+	key := fmt.Sprintf(ATTACK_FLOW_CACHE_KEY_FORMAT, cloudID, resourceName)
+	hash := md5.Sum([]byte(key))
+	return []byte(hash[:])
+}
+
+func setAttackFlowCache(cloudID, resourceName string, data *datasource.Resource) error {
+	key := generateCacheKey(cloudID, resourceName)
+	buf, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return attackFlowCache.Set(key, buf, ATTACK_FLOW_CACHE_EXPIRE_SEC)
+}
+
+func getAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, error) {
+	cacheKey := generateCacheKey(cloudID, resourceName)
+	buf, err := attackFlowCache.Get(cacheKey)
+	if err != nil {
+		if err.Error() == freecache.ErrNotFound.Error() {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(buf) == 0 {
+		return nil, nil
+	}
+	var resource datasource.Resource
+	if err := json.Unmarshal(buf, &resource); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+func getS3AttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *S3Metadata, error) {
+	resource, err := getAttackFlowCache(cloudID, resourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resource == nil {
+		return nil, nil, nil
+	}
+	var meta S3Metadata
+	if err := json.Unmarshal([]byte(resource.MetaData), &meta); err != nil {
+		return nil, nil, err
+	}
+	return resource, &meta, nil
+}
+
+func getLambdaAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *lambdaMetadata, error) {
+	resource, err := getAttackFlowCache(cloudID, resourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resource == nil {
+		return nil, nil, nil
+	}
+	var meta lambdaMetadata
+	if err := json.Unmarshal([]byte(resource.MetaData), &meta); err != nil {
+		return nil, nil, err
+	}
+	return resource, &meta, nil
+}
+
+func getEC2AttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *ec2Metadata, error) {
+	resource, err := getAttackFlowCache(cloudID, resourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resource == nil {
+		return nil, nil, nil
+	}
+	var meta ec2Metadata
+	if err := json.Unmarshal([]byte(resource.MetaData), &meta); err != nil {
+		return nil, nil, err
+	}
+	return resource, &meta, nil
+}
+
+func getAppRunnerAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *appRunnerMetadata, error) {
+	resource, err := getAttackFlowCache(cloudID, resourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resource == nil {
+		return nil, nil, nil
+	}
+	var meta appRunnerMetadata
+	if err := json.Unmarshal([]byte(resource.MetaData), &meta); err != nil {
+		return nil, nil, err
+	}
+	return resource, &meta, nil
+}
+
+func getIAMRunnerAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *iamMetadata, error) {
+	resource, err := getAttackFlowCache(cloudID, resourceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resource == nil {
+		return nil, nil, nil
+	}
+	var meta iamMetadata
+	if err := json.Unmarshal([]byte(resource.MetaData), &meta); err != nil {
+		return nil, nil, err
+	}
+	return resource, &meta, nil
+}

--- a/pkg/attackflow/cache.go
+++ b/pkg/attackflow/cache.go
@@ -112,7 +112,7 @@ func getAppRunnerAttackFlowCache(cloudID, resourceName string) (*datasource.Reso
 	return resource, &meta, nil
 }
 
-func getIAMRunnerAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *iamMetadata, error) {
+func getIAMAttackFlowCache(cloudID, resourceName string) (*datasource.Resource, *iamMetadata, error) {
 	resource, err := getAttackFlowCache(cloudID, resourceName)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/attackflow/chace_test.go
+++ b/pkg/attackflow/chace_test.go
@@ -1,0 +1,252 @@
+package attackflow
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ca-risken/datasource-api/proto/datasource"
+)
+
+func TestGetS3AttackFlowCache(t *testing.T) {
+	type args struct {
+		cloudID      string
+		resourceName string
+		resource     *datasource.Resource
+	}
+	type output struct {
+		resource *datasource.Resource
+		meta     *S3Metadata
+	}
+	cases := []struct {
+		name    string
+		input   args
+		want    output
+		wantErr bool
+	}{
+		{
+			name: "OK",
+			input: args{
+				cloudID:      "123456789012",
+				resourceName: "arn:aws:s3:::bucket-name",
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:s3:::bucket-name",
+					MetaData:     `{"is_public":true}`,
+				},
+			},
+			want: output{
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:s3:::bucket-name",
+					MetaData:     `{"is_public":true}`,
+				},
+				meta: &S3Metadata{
+					IsPublic: true,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// set cache
+			_ = setAttackFlowCache(c.input.cloudID, c.input.resourceName, c.input.resource)
+			// get cache
+			gotResource, gotMeta, err := getS3AttackFlowCache(c.input.cloudID, c.input.resourceName)
+			if err != nil && !c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if err == nil && c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(gotResource, c.want.resource) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.resource, gotResource)
+			}
+			if !reflect.DeepEqual(gotMeta, c.want.meta) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.meta, gotMeta)
+			}
+		})
+	}
+}
+
+func TestGetLambdaAttackFlowCache(t *testing.T) {
+	type args struct {
+		cloudID      string
+		resourceName string
+		resource     *datasource.Resource
+	}
+	type output struct {
+		resource *datasource.Resource
+		meta     *lambdaMetadata
+	}
+	cases := []struct {
+		name    string
+		input   args
+		want    output
+		wantErr bool
+	}{
+		{
+			name: "OK",
+			input: args{
+				cloudID:      "123456789012",
+				resourceName: "arn:aws:lambda:ap-northeast-1:123456789012:function:func-name",
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:lambda:ap-northeast-1:123456789012:function:func-name",
+					MetaData:     `{"is_public":true}`,
+				},
+			},
+			want: output{
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:lambda:ap-northeast-1:123456789012:function:func-name",
+					MetaData:     `{"is_public":true}`,
+				},
+				meta: &lambdaMetadata{
+					IsPublic: true,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// set cache
+			_ = setAttackFlowCache(c.input.cloudID, c.input.resourceName, c.input.resource)
+			// get cache
+			gotResource, gotMeta, err := getLambdaAttackFlowCache(c.input.cloudID, c.input.resourceName)
+			if err != nil && !c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if err == nil && c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(gotResource, c.want.resource) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.resource, gotResource)
+			}
+			if !reflect.DeepEqual(gotMeta, c.want.meta) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.meta, gotMeta)
+			}
+		})
+	}
+}
+
+func TestGetEC2AttackFlowCache(t *testing.T) {
+	type args struct {
+		cloudID      string
+		resourceName string
+		resource     *datasource.Resource
+	}
+	type output struct {
+		resource *datasource.Resource
+		meta     *ec2Metadata
+	}
+	cases := []struct {
+		name    string
+		input   args
+		want    output
+		wantErr bool
+	}{
+		{
+			name: "OK",
+			input: args{
+				cloudID:      "123456789012",
+				resourceName: "arn:aws:ec2:us-east-1:123456789012:instance/i-xxxxxxx",
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:ec2:us-east-1:123456789012:instance/i-xxxxxxx",
+					MetaData:     `{"is_public":true}`,
+				},
+			},
+			want: output{
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:ec2:us-east-1:123456789012:instance/i-xxxxxxx",
+					MetaData:     `{"is_public":true}`,
+				},
+				meta: &ec2Metadata{
+					IsPublic: true,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// set cache
+			_ = setAttackFlowCache(c.input.cloudID, c.input.resourceName, c.input.resource)
+			// get cache
+			gotResource, gotMeta, err := getEC2AttackFlowCache(c.input.cloudID, c.input.resourceName)
+			if err != nil && !c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if err == nil && c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(gotResource, c.want.resource) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.resource, gotResource)
+			}
+			if !reflect.DeepEqual(gotMeta, c.want.meta) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.meta, gotMeta)
+			}
+		})
+	}
+}
+
+func TestGetAppRunnerAttackFlowCache(t *testing.T) {
+	type args struct {
+		cloudID      string
+		resourceName string
+		resource     *datasource.Resource
+	}
+	type output struct {
+		resource *datasource.Resource
+		meta     *appRunnerMetadata
+	}
+	cases := []struct {
+		name    string
+		input   args
+		want    output
+		wantErr bool
+	}{
+		{
+			name: "OK",
+			input: args{
+				cloudID:      "123456789012",
+				resourceName: "arn:aws:apprunner:ap-northeast-1:123456789012:service/service-name/xxx",
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:apprunner:ap-northeast-1:123456789012:service/service-name/xxx",
+					MetaData:     `{"is_public":true}`,
+				},
+			},
+			want: output{
+				resource: &datasource.Resource{
+					CloudId:      "123456789012",
+					ResourceName: "arn:aws:apprunner:ap-northeast-1:123456789012:service/service-name/xxx",
+					MetaData:     `{"is_public":true}`,
+				},
+				meta: &appRunnerMetadata{
+					IsPublic: true,
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// set cache
+			_ = setAttackFlowCache(c.input.cloudID, c.input.resourceName, c.input.resource)
+			// get cache
+			gotResource, gotMeta, err := getAppRunnerAttackFlowCache(c.input.cloudID, c.input.resourceName)
+			if err != nil && !c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if err == nil && c.wantErr {
+				t.Errorf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(gotResource, c.want.resource) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.resource, gotResource)
+			}
+			if !reflect.DeepEqual(gotMeta, c.want.meta) {
+				t.Errorf("Unexpected response: want=%+v, got=%+v", c.want.meta, gotMeta)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- CloudFront -> ELBのフローをサポートします
- CloudFront -> API Gatewayのフローをサポートします
- EC2などのCompute関連やIAMなど、一度の分析に重複して解析される可能性が高いサービスは解析結果をキャッシュするようにしました