### PR TITLE
fix launch server

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+if [ -z "$GOOGLE_SERVICE_ACCOUNT_JSON" ]; then
+  exec "$@"
+fi
+
 CREDENTIAL_FILE="/tmp/credential.json"
 if [ -n "$GOOGLE_CREDENTIAL_PATH" ]; then
   CREDENTIAL_FILE=$GOOGLE_CREDENTIAL_PATH

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -31,10 +31,6 @@ type GcpClient struct {
 }
 
 func NewGcpClient(ctx context.Context, credentialPath string, l logging.Logger) (GcpServiceClient, error) {
-	as, err := asset.NewClient(ctx, option.WithCredentialsFile(credentialPath))
-	if err != nil {
-		return nil, fmt.Errorf("failed to authenticate for Google Asset API client: %w", err)
-	}
 	crm, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new Cloud Resource Manager service: err=%w", err)
@@ -42,6 +38,10 @@ func NewGcpClient(ctx context.Context, credentialPath string, l logging.Logger) 
 	compute, err := compute.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new Compute service: err=%w", err)
+	}
+	as, err := asset.NewClient(ctx, option.WithCredentialsFile(credentialPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate for Google Asset API client: %w", err)
 	}
 
 	// Remove credential file for Security

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -31,6 +31,12 @@ type GcpClient struct {
 }
 
 func NewGcpClient(ctx context.Context, credentialPath string, l logging.Logger) (GcpServiceClient, error) {
+	if _, err := os.Stat(credentialPath); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to check google credential file: %w", err)
+	}
+
 	crm, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsFile(credentialPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new Cloud Resource Manager service: err=%w", err)

--- a/pkg/server/google/google.go
+++ b/pkg/server/google/google.go
@@ -204,6 +204,9 @@ func (g *GoogleService) GetGCPDataSource(ctx context.Context, req *google.GetGCP
 }
 
 func (g *GoogleService) AttachGCPDataSource(ctx context.Context, req *google.AttachGCPDataSourceRequest) (*google.AttachGCPDataSourceResponse, error) {
+	if g.gcpClient == nil {
+		return nil, fmt.Errorf("gcp client is not enabled")
+	}
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -245,6 +248,11 @@ const (
 )
 
 func (g *GoogleService) InvokeScanGCP(ctx context.Context, req *google.InvokeScanGCPRequest) (*google.Empty, error) {
+	if g.gcpClient == nil {
+		if g.gcpClient == nil {
+			return nil, fmt.Errorf("gcp client is not enabled")
+		}
+	}
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/server/google/google.go
+++ b/pkg/server/google/google.go
@@ -249,9 +249,7 @@ const (
 
 func (g *GoogleService) InvokeScanGCP(ctx context.Context, req *google.InvokeScanGCPRequest) (*google.Empty, error) {
 	if g.gcpClient == nil {
-		if g.gcpClient == nil {
-			return nil, fmt.Errorf("gcp client is not enabled")
-		}
+		return nil, fmt.Errorf("gcp client is not enabled")
 	}
 	if err := req.Validate(); err != nil {
 		return nil, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,9 +81,15 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create alert client: %w", err)
 	}
-	gcpClient, err := gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
-	if err != nil {
-		return fmt.Errorf("failed to create gcp client: %w", err)
+	var gcpClient gcp.GcpServiceClient
+	if _, err := os.Stat(s.googleCredentialPath); os.IsNotExist(err) {
+		s.logger.Warnf(ctx, "Google credential file not exists at %s", s.googleCredentialPath)
+		s.logger.Warn(ctx, "Google service will not be available")
+	} else {
+		gcpClient, err = gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
+		if err != nil {
+			return fmt.Errorf("failed to create gcp client: %w", err)
+		}
 	}
 	azureClient, err := azureClient.NewAzureClient(ctx, s.logger)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,7 +85,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if _, err := os.Stat(s.googleCredentialPath); os.IsNotExist(err) {
 		s.logger.Warnf(ctx, "Google credential file not exists at %s", s.googleCredentialPath)
 		s.logger.Warn(ctx, "Google service will not be available")
-	} else {
+	} else if err != nil {
 		gcpClient, err = gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
 		if err != nil {
 			return fmt.Errorf("failed to create gcp client: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -81,17 +81,13 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create alert client: %w", err)
 	}
-	var gcpClient gcp.GcpServiceClient
-	if _, err := os.Stat(s.googleCredentialPath); os.IsNotExist(err) {
+	gcpClient, err := gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
+	if err != nil {
+		return fmt.Errorf("failed to create gcp client: %w", err)
+	}
+	if gcpClient == nil {
 		s.logger.Warnf(ctx, "Google credential file not exists at %s", s.googleCredentialPath)
 		s.logger.Warn(ctx, "Google service will not be available")
-	} else if err != nil {
-		return fmt.Errorf("failed to check google credential file: %w", err)
-	} else {
-		gcpClient, err = gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
-		if err != nil {
-			return fmt.Errorf("failed to create gcp client: %w", err)
-		}
 	}
 	azureClient, err := azureClient.NewAzureClient(ctx, s.logger)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -86,6 +86,8 @@ func (s *Server) Run(ctx context.Context) error {
 		s.logger.Warnf(ctx, "Google credential file not exists at %s", s.googleCredentialPath)
 		s.logger.Warn(ctx, "Google service will not be available")
 	} else if err != nil {
+		return fmt.Errorf("failed to check google credential file: %w", err)
+	} else {
 		gcpClient, err = gcp.NewGcpClient(ctx, s.googleCredentialPath, s.logger)
 		if err != nil {
 			return fmt.Errorf("failed to create gcp client: %w", err)


### PR DESCRIPTION
正しいGCPのクレデンシャルを環境変数に設定していないとサーバーが立ち上がらない問題を修正します

- 環境変数のGOOGLE_SERVICE_ACCOUNT_JSONの値が空の場合に、クレデンシャルファイルを作成しない
- クレデンシャルファイルが存在しない場合、Google用のClientを作成しない
- GoogleのClientが作成されていない場合、AttachとInvokeスキャン実行時にエラーにするよう修正
  - PutGCP自体は、GCPClientを介さないのでエラーにする処理はいれていません
