### PR TITLE
Add GitHub Actions workflow for building and tagging PR Datasource API container update Makefile with new test target

### DIFF
--- a/.github/workflows/build-pr-datasource-api.yml
+++ b/.github/workflows/build-pr-datasource-api.yml
@@ -1,0 +1,20 @@
+name: Build and Tag Container for PR Datasource API
+
+on: 
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build-pr-datasource-api:
+    uses: ca-risken/.github/.github/workflows/build-pr.yml@main
+    with:
+      runs_on: codebuild-mimosa-datasource-api-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
+      install_go_version: "1.23.3"
+      golangci_lint_version: "v1.62.0"
+      image_prefix: "risken-datasource-api"
+      aws_xray_sdk_disabled: "true"
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}

--- a/.github/workflows/build-pr-datasource-api.yml
+++ b/.github/workflows/build-pr-datasource-api.yml
@@ -10,8 +10,8 @@ jobs:
     uses: ca-risken/.github/.github/workflows/build-pr.yml@main
     with:
       runs_on: codebuild-mimosa-datasource-api-pr-runner-${{ github.run_id }}-${{ github.run_attempt }}
-      install_go_version: "1.23.3"
-      golangci_lint_version: "v1.62.0"
+      install_go_version: "1.18.2"
+      golangci_lint_version: "v1.50.1"
       image_prefix: "risken-datasource-api"
       aws_xray_sdk_disabled: "true"
     secrets:

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test:
 	GO111MODULE=on go test ./...
 
 PHONY: go-test
-test:
+go-test:
 	GO111MODULE=on go test ./...
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ PHONY: test
 test:
 	GO111MODULE=on go test ./...
 
+PHONY: go-test
+test:
+	GO111MODULE=on go test ./...
+
 .PHONY: lint
 lint: FAKE
 	GO111MODULE=on GOFLAGS=-buildvcs=false golangci-lint run --timeout 5m


### PR DESCRIPTION
datasource-apiに関連付けられていたcodebuildを置き換えるためにgithub actionsのワークフローを追加します。
awsやcoreのものとgolangのバージョンを除き、同じ内容です。