### PR TITLE
[add]skipScanの処理もdatasource-apiに移管

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,9 @@ type AppConf struct {
 	DBPort           int    `required:"true"    default:"3306"`
 	DBLogMode        bool   `split_words:"true" default:"false"`
 	DBMaxConnection  int    `split_words:"true" default:"10"`
+
+	// scan settings
+	LimitRepositorySizeKb int `split_words:"true" default:"500000"` // 500MB
 }
 
 func main() {
@@ -179,6 +182,7 @@ func main() {
 		conf.BaseURL,
 		conf.DefaultLocale,
 		conf.SlackAPIToken,
+		conf.LimitRepositorySizeKb,
 		logger,
 	)
 

--- a/pkg/github/filter.go
+++ b/pkg/github/filter.go
@@ -92,13 +92,8 @@ func FilterByVisibility(repos []*github.Repository, scanPublic, scanInternal, sc
 	return filteredRepos
 }
 
-// ApplyFilters applies all filters specified in FilterOptions to the repository list
-// Excluded repositories (archived, fork, disabled, empty, oversized) are filtered out first,
-// then visibility and name pattern filters are applied
-func ApplyFilters(repos []*github.Repository, opts *FilterOptions, limitRepositorySizeKb int) []*github.Repository {
-	// Always apply exclusion filters first (regardless of opts)
-	repos = FilterExcludedRepositories(repos, limitRepositorySizeKb)
-
+// ApplyFilters applies visibility and name pattern filters specified in FilterOptions
+func ApplyFilters(repos []*github.Repository, opts *FilterOptions) []*github.Repository {
 	if opts == nil {
 		return repos
 	}

--- a/pkg/github/filter.go
+++ b/pkg/github/filter.go
@@ -41,6 +41,36 @@ func FilterByNamePattern(repos []*github.Repository, pattern string) []*github.R
 	return filteredRepos
 }
 
+// FilterExcludedRepositories filters out repositories that should be excluded from scanning
+// Excludes: Archived, Fork, Disabled, empty (Size == 0), and oversized repositories
+func FilterExcludedRepositories(repos []*github.Repository, limitRepositorySizeKb int) []*github.Repository {
+	filteredRepos := make([]*github.Repository, 0)
+	for _, repo := range repos {
+		// Exclude archived repositories
+		if repo.Archived != nil && *repo.Archived {
+			continue
+		}
+		// Exclude fork repositories
+		if repo.Fork != nil && *repo.Fork {
+			continue
+		}
+		// Exclude disabled repositories
+		if repo.Disabled != nil && *repo.Disabled {
+			continue
+		}
+		// Exclude empty repositories (Size == 0)
+		if repo.Size != nil && *repo.Size == 0 {
+			continue
+		}
+		// Exclude repositories exceeding size limit
+		if repo.Size != nil && *repo.Size > limitRepositorySizeKb {
+			continue
+		}
+		filteredRepos = append(filteredRepos, repo)
+	}
+	return filteredRepos
+}
+
 // FilterByVisibility filters repositories by visibility
 func FilterByVisibility(repos []*github.Repository, scanPublic, scanInternal, scanPrivate bool) []*github.Repository {
 	filteredRepos := make([]*github.Repository, 0)
@@ -63,12 +93,17 @@ func FilterByVisibility(repos []*github.Repository, scanPublic, scanInternal, sc
 }
 
 // ApplyFilters applies all filters specified in FilterOptions to the repository list
-func ApplyFilters(repos []*github.Repository, opts *FilterOptions) []*github.Repository {
+// Excluded repositories (archived, fork, disabled, empty, oversized) are filtered out first,
+// then visibility and name pattern filters are applied
+func ApplyFilters(repos []*github.Repository, opts *FilterOptions, limitRepositorySizeKb int) []*github.Repository {
+	// Always apply exclusion filters first (regardless of opts)
+	repos = FilterExcludedRepositories(repos, limitRepositorySizeKb)
+
 	if opts == nil {
 		return repos
 	}
 
-	// Apply visibility filter first
+	// Apply visibility filter
 	repos = FilterByVisibility(repos, opts.ScanPublic, opts.ScanInternal, opts.ScanPrivate)
 
 	// Then apply name pattern filter

--- a/pkg/github/filter_test.go
+++ b/pkg/github/filter_test.go
@@ -289,7 +289,6 @@ func TestFilterByVisibility(t *testing.T) {
 func TestApplyFilters(t *testing.T) {
 	visibilityPublic := "public"
 	visibilityPrivate := "private"
-	const testLimitRepositorySizeKb = 100000
 	type args struct {
 		repos []*github.Repository
 		opts  *FilterOptions
@@ -405,7 +404,7 @@ func TestApplyFilters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ApplyFilters(tt.args.repos, tt.args.opts, testLimitRepositorySizeKb); !reflect.DeepEqual(got, tt.want) {
+			if got := ApplyFilters(tt.args.repos, tt.args.opts); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ApplyFilters() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/github/filter_test.go
+++ b/pkg/github/filter_test.go
@@ -289,6 +289,7 @@ func TestFilterByVisibility(t *testing.T) {
 func TestApplyFilters(t *testing.T) {
 	visibilityPublic := "public"
 	visibilityPrivate := "private"
+	const testLimitRepositorySizeKb = 100000
 	type args struct {
 		repos []*github.Repository
 		opts  *FilterOptions
@@ -404,7 +405,7 @@ func TestApplyFilters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ApplyFilters(tt.args.repos, tt.args.opts); !reflect.DeepEqual(got, tt.want) {
+			if got := ApplyFilters(tt.args.repos, tt.args.opts, testLimitRepositorySizeKb); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ApplyFilters() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -705,8 +705,8 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 		return nil, err
 	}
 
+	repos = github.FilterExcludedRepositories(repos, c.limitRepositorySizeKb)
 	if codeScanSetting != nil {
-		repos = github.FilterExcludedRepositories(repos, c.limitRepositorySizeKb)
 		filterOpts := &github.FilterOptions{
 			RepositoryPattern: codeScanSetting.RepositoryPattern,
 			ScanPublic:        codeScanSetting.ScanPublic,

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -713,7 +713,7 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 			ScanInternal:      codeScanSetting.ScanInternal,
 			ScanPrivate:       codeScanSetting.ScanPrivate,
 		}
-		repos = github.ApplyFilters(repos, filterOpts)
+		repos = github.ApplyFilters(repos, filterOpts, c.limitRepositorySizeKb)
 	}
 
 	return repos, nil

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -705,15 +705,15 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 		return nil, err
 	}
 
-	// Apply filters only if CodeScanSetting exists
 	if codeScanSetting != nil {
+		repos = github.FilterExcludedRepositories(repos, c.limitRepositorySizeKb)
 		filterOpts := &github.FilterOptions{
 			RepositoryPattern: codeScanSetting.RepositoryPattern,
 			ScanPublic:        codeScanSetting.ScanPublic,
 			ScanInternal:      codeScanSetting.ScanInternal,
 			ScanPrivate:       codeScanSetting.ScanPrivate,
 		}
-		repos = github.ApplyFilters(repos, filterOpts, c.limitRepositorySizeKb)
+		repos = github.ApplyFilters(repos, filterOpts)
 	}
 
 	return repos, nil

--- a/pkg/server/code/service.go
+++ b/pkg/server/code/service.go
@@ -25,13 +25,14 @@ type CodeService struct {
 	codeDependencyQueueURL string
 	codeCodeScanQueueURL   string
 	githubClient           github.GithubServiceClient
+	limitRepositorySizeKb  int
 }
 
 type CodeQueue interface {
 	Send(ctx context.Context, url string, msg interface{}) (*sqs.SendMessageOutput, error)
 }
 
-func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, l logging.Logger) (code.CodeServiceServer, error) {
+func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, limitRepositorySizeKb int, l logging.Logger) (code.CodeServiceServer, error) {
 	key := []byte(dataKey)
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -50,5 +51,6 @@ func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, 
 		codeDependencyQueueURL: q.CodeDependencyQueueURL,
 		codeCodeScanQueueURL:   q.CodeCodeScanQueueURL,
 		githubClient:           githubClient,
+		limitRepositorySizeKb: limitRepositorySizeKb,
 	}, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,10 +52,11 @@ type Server struct {
 	baseURL              string
 	defaultLocale        string
 	slackAPIToken        string
+	limitRepositorySizeKb int
 	logger               logging.Logger
 }
 
-func NewServer(port, coreSvcAddr, awsRegion, googleCredentialPath, dataKey string, db *db.Client, q *queue.Client, url, defaultLocale, slackAPIToken string, logger logging.Logger) *Server {
+func NewServer(port, coreSvcAddr, awsRegion, googleCredentialPath, dataKey string, db *db.Client, q *queue.Client, url, defaultLocale, slackAPIToken string, limitRepositorySizeKb int, logger logging.Logger) *Server {
 	return &Server{
 		port:                 port,
 		coreSvcAddr:          coreSvcAddr,
@@ -67,6 +68,7 @@ func NewServer(port, coreSvcAddr, awsRegion, googleCredentialPath, dataKey strin
 		baseURL:              url,
 		defaultLocale:        defaultLocale,
 		slackAPIToken:        slackAPIToken,
+		limitRepositorySizeKb: limitRepositorySizeKb,
 		logger:               logger,
 	}
 }
@@ -97,7 +99,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	awsSvc := awsServer.NewAWSService(s.db, s.queue, pjClient, s.logger)
 	googleSvc := googleServer.NewGoogleService(ctx, gcpClient, s.db, s.queue, pjClient, s.logger)
-	codeSvc, err := codeServer.NewCodeService(s.dataKey, s.db, s.queue, pjClient, s.logger)
+	codeSvc, err := codeServer.NewCodeService(s.dataKey, s.db, s.queue, pjClient, s.limitRepositorySizeKb, s.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create code service: %w", err)
 	}


### PR DESCRIPTION
ListRepositoryをdatasource-api側で移管して、RPCとして参照することにより、既存のcodeにおけるListRepositoryのレスポンスと型の不一致が起きました。

これにより、skipScan処理に必要なフィールドが得られなくなったため、skipScan処理もdatasource-api側に移管した方が良いと思い、本PRを出しています。

こちらでは、フィルタ処理の一部として、`FilterExcludedRepositories`という関数名で実装しています。