### PR TITLE
[add]decrypt-pat

### DIFF
--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -706,7 +706,9 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 		}
 		decryptedPAT = decrypted
 		if decryptedPAT == "" {
-			c.logger.Warnf(ctx, "Decrypted PAT is empty for github_setting_id=%d", githubSettingID)
+			err := fmt.Errorf("decrypted PAT is empty")
+			c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v, github_setting_id=%d", err, githubSettingID)
+			return nil, err
 		}
 	} else {
 		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -706,9 +706,8 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 		}
 		decryptedPAT = decrypted
 		if decryptedPAT == "" {
-			err := fmt.Errorf("decrypted PAT is empty")
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v, github_setting_id=%d", err, githubSettingID)
-			return nil, err
+			c.logger.Errorf(ctx, "Failed to decrypt PAT: decrypted PAT is empty, project_id=%d, github_setting_id=%d", projectID, githubSettingID)
+			return nil, fmt.Errorf("decrypted PAT is empty")
 		}
 	} else {
 		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)

--- a/pkg/server/code/crypto.go
+++ b/pkg/server/code/crypto.go
@@ -32,3 +32,32 @@ func encrypt(block *cipher.Block, plainText string) ([]byte, error) {
 	encrypter.CryptBlocks(encrypted[aes.BlockSize:], []byte(paddedText))
 	return encrypted, nil
 }
+
+func decryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
+	if encrypted == "" {
+		return "", nil
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", err
+	}
+	decrypted := decrypt(block, decoded)
+	if len(decrypted) < 1 {
+		return "", nil
+	}
+
+	// Unpadding
+	padSize := int(decrypted[len(decrypted)-1])
+	return string(decrypted[:len(decrypted)-padSize]), nil
+}
+
+func decrypt(block *cipher.Block, encrypted []byte) []byte {
+	if len(encrypted) < aes.BlockSize {
+		return []byte("")
+	}
+	iv := encrypted[:aes.BlockSize] // Get Initial Vector form first head block.
+	decrypted := make([]byte, len(encrypted[aes.BlockSize:]))
+	decrypter := cipher.NewCBCDecrypter(*block, iv)
+	decrypter.CryptBlocks(decrypted, encrypted[aes.BlockSize:])
+	return decrypted
+}

--- a/pkg/server/code/crypto_test.go
+++ b/pkg/server/code/crypto_test.go
@@ -2,8 +2,6 @@ package code
 
 import (
 	"crypto/aes"
-	"crypto/cipher"
-	"encoding/base64"
 	"reflect"
 	"testing"
 )
@@ -41,7 +39,7 @@ func TestEncryptDecrypt(t *testing.T) {
 				t.Fatalf("Unexpected error occured, err=%+v", err)
 			}
 
-			decrypted, err := TestdecryptWithBase64(&block, encrypted)
+			decrypted, err := decryptWithBase64(&block, encrypted)
 			if c.wantDecError && err == nil {
 				t.Fatal("Unexpected no error")
 			}
@@ -54,29 +52,4 @@ func TestEncryptDecrypt(t *testing.T) {
 			}
 		})
 	}
-}
-func TestdecryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
-	decoded, err := base64.RawStdEncoding.DecodeString(encrypted)
-	if err != nil {
-		return "", err
-	}
-	decrypted := Testdecrypt(block, decoded)
-	if len(decrypted) < 1 {
-		return "", nil
-	}
-
-	// Unpadding
-	padSize := int(decrypted[len(decrypted)-1])
-	return string(decrypted[:len(decrypted)-padSize]), nil
-}
-
-func Testdecrypt(block *cipher.Block, encrypted []byte) []byte {
-	if len(encrypted) < aes.BlockSize {
-		return []byte("")
-	}
-	iv := encrypted[:aes.BlockSize] // Get Initial Vector form first head block.
-	decrypted := make([]byte, len(encrypted[aes.BlockSize:]))
-	decrypter := cipher.NewCBCDecrypter(*block, iv)
-	decrypter.CryptBlocks(decrypted, encrypted[aes.BlockSize:])
-	return decrypted
 }

--- a/pkg/server/code/crypto_test.go
+++ b/pkg/server/code/crypto_test.go
@@ -41,7 +41,7 @@ func TestEncryptDecrypt(t *testing.T) {
 				t.Fatalf("Unexpected error occured, err=%+v", err)
 			}
 
-			decrypted, err := decryptWithBase64(&block, encrypted)
+			decrypted, err := TestdecryptWithBase64(&block, encrypted)
 			if c.wantDecError && err == nil {
 				t.Fatal("Unexpected no error")
 			}
@@ -55,13 +55,12 @@ func TestEncryptDecrypt(t *testing.T) {
 		})
 	}
 }
-
-func decryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
+func TestdecryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
 	decoded, err := base64.RawStdEncoding.DecodeString(encrypted)
 	if err != nil {
 		return "", err
 	}
-	decrypted := decrypt(block, decoded)
+	decrypted := Testdecrypt(block, decoded)
 	if len(decrypted) < 1 {
 		return "", nil
 	}
@@ -71,7 +70,7 @@ func decryptWithBase64(block *cipher.Block, encrypted string) (string, error) {
 	return string(decrypted[:len(decrypted)-padSize]), nil
 }
 
-func decrypt(block *cipher.Block, encrypted []byte) []byte {
+func Testdecrypt(block *cipher.Block, encrypted []byte) []byte {
 	if len(encrypted) < aes.BlockSize {
 		return []byte("")
 	}


### PR DESCRIPTION
pat復号の処理が不足しており、ListCodescanTargetRepository()を呼び出して動作確認した際にエラーが出たため追加
(ハンドラ側ではなく、あらかじめdatasource-api側でpatの復号が必要だった。)