### PR TITLE
[add]github-client-error-process

### DIFF
--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -18,23 +17,6 @@ import (
 	"github.com/vikyd/zero"
 	"gorm.io/gorm"
 )
-
-// isGitHubClientError checks if the error is a GitHub 4xx error
-// by checking for ErrorResponse with 400-499 status code.
-func isGitHubClientError(err error) bool {
-	if err == nil {
-		return false
-	}
-	var errResp *ghub.ErrorResponse
-	if errors.As(err, &errResp) {
-		if errResp.Response == nil {
-			return false
-		}
-		code := errResp.Response.StatusCode
-		return code >= http.StatusBadRequest && code < http.StatusInternalServerError
-	}
-	return false
-}
 
 // sanitizeErrorMessage removes potentially sensitive information from error messages
 // Returns a user-friendly message without internal details
@@ -518,26 +500,23 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 	// Get list of repositories filtered by GitleaksSetting (RepositoryPattern, ScanPublic/Internal/Private, etc.)
 	repos, err := c.listGitleaksTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		if isGitHubClientError(err) {
-			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
-			if _, updateErr := c.repository.UpsertGitleaksSetting(ctx, &code.GitleaksSettingForUpsert{
-				GithubSettingId:   data.CodeGitHubSettingID,
-				CodeDataSourceId:  data.CodeDataSourceID,
-				ProjectId:         data.ProjectID,
-				RepositoryPattern: data.RepositoryPattern,
-				ScanPublic:        data.ScanPublic,
-				ScanInternal:      data.ScanInternal,
-				ScanPrivate:       data.ScanPrivate,
-				Status:            code.Status_ERROR,
-				StatusDetail:      sanitizeErrorMessage(err),
-				ScanAt:            data.ScanAt.Unix(),
-			}); updateErr != nil {
-				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
-				return nil, fmt.Errorf("failed to update status: %w", updateErr)
-			}
-			return nil, fmt.Errorf("GitHub client error: %w", err)
+		c.logger.Errorf(ctx, "Error listing repositories for gitleaks: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
+		if _, updateErr := c.repository.UpsertGitleaksSetting(ctx, &code.GitleaksSettingForUpsert{
+			GithubSettingId:   data.CodeGitHubSettingID,
+			CodeDataSourceId:  data.CodeDataSourceID,
+			ProjectId:         data.ProjectID,
+			RepositoryPattern: data.RepositoryPattern,
+			ScanPublic:        data.ScanPublic,
+			ScanInternal:      data.ScanInternal,
+			ScanPrivate:       data.ScanPrivate,
+			Status:            code.Status_ERROR,
+			StatusDetail:      sanitizeErrorMessage(err),
+			ScanAt:            data.ScanAt.Unix(),
+		}); updateErr != nil {
+			c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
+			return nil, fmt.Errorf("failed to update status: %w", updateErr)
 		}
-		return nil, err
+		return nil, fmt.Errorf("listing repositories: %w", err)
 	}
 
 	if len(repos) == 0 {
@@ -607,23 +586,20 @@ func (c *CodeService) InvokeScanDependency(ctx context.Context, req *code.Invoke
 	// Get list of repositories filtered by DependencySetting (RepositoryPattern)
 	repos, err := c.listDependencyTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		if isGitHubClientError(err) {
-			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
-			if _, updateErr := c.repository.UpsertDependencySetting(ctx, &code.DependencySettingForUpsert{
-				GithubSettingId:   data.CodeGitHubSettingID,
-				CodeDataSourceId:  data.CodeDataSourceID,
-				ProjectId:         data.ProjectID,
-				RepositoryPattern: data.RepositoryPattern,
-				Status:            code.Status_ERROR,
-				StatusDetail:      sanitizeErrorMessage(err),
-				ScanAt:            data.ScanAt.Unix(),
-			}); updateErr != nil {
-				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
-				return nil, fmt.Errorf("failed to update status: %w", updateErr)
-			}
-			return nil, fmt.Errorf("GitHub client error: %w", err)
+		c.logger.Errorf(ctx, "Error listing repositories for dependency: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
+		if _, updateErr := c.repository.UpsertDependencySetting(ctx, &code.DependencySettingForUpsert{
+			GithubSettingId:   data.CodeGitHubSettingID,
+			CodeDataSourceId:  data.CodeDataSourceID,
+			ProjectId:         data.ProjectID,
+			RepositoryPattern: data.RepositoryPattern,
+			Status:            code.Status_ERROR,
+			StatusDetail:      sanitizeErrorMessage(err),
+			ScanAt:            data.ScanAt.Unix(),
+		}); updateErr != nil {
+			c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
+			return nil, fmt.Errorf("failed to update status: %w", updateErr)
 		}
-		return nil, err
+		return nil, fmt.Errorf("listing repositories: %w", err)
 	}
 
 	if len(repos) == 0 {
@@ -688,30 +664,23 @@ func (c *CodeService) InvokeScanCodeScan(ctx context.Context, req *code.InvokeSc
 	// Get list of repositories filtered by CodeScanSetting (RepositoryPattern, ScanPublic/Internal/Private, etc.)
 	repos, err := c.listCodescanTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		// Check if error is GitHub client error (4xx) using error type
-		if isGitHubClientError(err) {
-			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
-			// Update status to ERROR with sanitized error message
-			if _, updateErr := c.repository.UpsertCodeScanSetting(ctx, &code.CodeScanSettingForUpsert{
-				GithubSettingId:   data.CodeGitHubSettingID,
-				CodeDataSourceId:  data.CodeDataSourceID,
-				ProjectId:         data.ProjectID,
-				RepositoryPattern: data.RepositoryPattern,
-				ScanPublic:        data.ScanPublic,
-				ScanInternal:      data.ScanInternal,
-				ScanPrivate:       data.ScanPrivate,
-				Status:            code.Status_ERROR,
-				StatusDetail:      sanitizeErrorMessage(err),
-				ScanAt:            data.ScanAt.Unix(),
-			}); updateErr != nil {
-				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
-				return nil, fmt.Errorf("failed to update status: %w", updateErr)
-			}
-			// Return client error to allow InvokeScanAll to handle it appropriately
-			return nil, fmt.Errorf("GitHub client error: %w", err)
+		c.logger.Errorf(ctx, "Error listing repositories for codescan: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
+		if _, updateErr := c.repository.UpsertCodeScanSetting(ctx, &code.CodeScanSettingForUpsert{
+			GithubSettingId:   data.CodeGitHubSettingID,
+			CodeDataSourceId:  data.CodeDataSourceID,
+			ProjectId:         data.ProjectID,
+			RepositoryPattern: data.RepositoryPattern,
+			ScanPublic:        data.ScanPublic,
+			ScanInternal:      data.ScanInternal,
+			ScanPrivate:       data.ScanPrivate,
+			Status:            code.Status_ERROR,
+			StatusDetail:      sanitizeErrorMessage(err),
+			ScanAt:            data.ScanAt.Unix(),
+		}); updateErr != nil {
+			c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
+			return nil, fmt.Errorf("failed to update status: %w", updateErr)
 		}
-		// For other errors, return error as before
-		return nil, err
+		return nil, fmt.Errorf("listing repositories: %w", err)
 	}
 
 	if len(repos) == 0 {
@@ -790,13 +759,8 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       g.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
-			if isGitHubClientError(err) {
-				c.logger.Errorf(ctx, "InvokeScanGitleaks github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
-				continue
-			}
-			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: code_github_setting_id=%d, err=%+v", g.CodeGitHubSettingID, err)
-			return nil, err
+			c.logger.Errorf(ctx, "InvokeScanGitleaks error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
+			continue
 		}
 	}
 	listDependency, err := c.repository.ListDependencySetting(ctx, 0)
@@ -819,13 +783,8 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       g.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
-			if isGitHubClientError(err) {
-				c.logger.Errorf(ctx, "InvokeScanDependency github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
-				continue
-			}
-			c.logger.Errorf(ctx, "InvokeScanDependency error occured: code_github_setting_id=%d, err=%+v", g.CodeGitHubSettingID, err)
-			return nil, err
+			c.logger.Errorf(ctx, "InvokeScanDependency error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
+			continue
 		}
 	}
 	listCodeScan, err := c.repository.ListCodeScanSetting(ctx, 0)
@@ -848,14 +807,8 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       codescan.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
-			if isGitHubClientError(err) {
-				c.logger.Errorf(ctx, "InvokeScanCodeScan github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", codescan.ProjectID, codescan.CodeGitHubSettingID, err)
-				continue
-			}
-			// For all other errors, return error to stop processing
-			c.logger.Errorf(ctx, "InvokeScanCodeScan error occured: project_id=%d, code_github_setting_id=%d, err=%+v", codescan.ProjectID, codescan.CodeGitHubSettingID, err)
-			return nil, err
+			c.logger.Errorf(ctx, "InvokeScanCodeScan error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", codescan.ProjectID, codescan.CodeGitHubSettingID, err)
+			continue
 		}
 	}
 	return &empty.Empty{}, nil

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -19,15 +19,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// isGitHubAuthError checks if the error is a GitHub authentication error
-// by checking for ErrorResponse with 401 status code
-func isGitHubAuthError(err error) bool {
+// isGitHubClientError checks if the error is a GitHub 4xx error
+// by checking for ErrorResponse with 400-499 status code.
+func isGitHubClientError(err error) bool {
 	if err == nil {
 		return false
 	}
 	var errResp *ghub.ErrorResponse
 	if errors.As(err, &errResp) {
-		return errResp.Response != nil && errResp.Response.StatusCode == http.StatusUnauthorized
+		if errResp.Response == nil {
+			return false
+		}
+		code := errResp.Response.StatusCode
+		return code >= http.StatusBadRequest && code < http.StatusInternalServerError
 	}
 	return false
 }
@@ -38,11 +42,7 @@ func sanitizeErrorMessage(err error) string {
 	if err == nil {
 		return ""
 	}
-	// Check if it's a GitHub authentication error
-	if isGitHubAuthError(err) {
-		return "GitHub authentication failed: Personal Access Token may be expired or invalid"
-	}
-	// For other errors, return a generic message without internal details
+	// Return a generic message without internal details
 	return "An error occurred during the operation"
 }
 
@@ -518,8 +518,8 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 	// Get list of repositories filtered by GitleaksSetting (RepositoryPattern, ScanPublic/Internal/Private, etc.)
 	repos, err := c.listGitleaksTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		if isGitHubAuthError(err) {
-			c.logger.Errorf(ctx, "GitHub API authentication error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v (PAT may be expired or invalid)", req.ProjectId, req.GithubSettingId, err)
+		if isGitHubClientError(err) {
+			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
 			if _, updateErr := c.repository.UpsertGitleaksSetting(ctx, &code.GitleaksSettingForUpsert{
 				GithubSettingId:   data.CodeGitHubSettingID,
 				CodeDataSourceId:  data.CodeDataSourceID,
@@ -535,7 +535,7 @@ func (c *CodeService) InvokeScanGitleaks(ctx context.Context, req *code.InvokeSc
 				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
 				return nil, fmt.Errorf("failed to update status: %w", updateErr)
 			}
-			return nil, fmt.Errorf("GitHub authentication error: %w", err)
+			return nil, fmt.Errorf("GitHub client error: %w", err)
 		}
 		return nil, err
 	}
@@ -607,8 +607,8 @@ func (c *CodeService) InvokeScanDependency(ctx context.Context, req *code.Invoke
 	// Get list of repositories filtered by DependencySetting (RepositoryPattern)
 	repos, err := c.listDependencyTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		if isGitHubAuthError(err) {
-			c.logger.Errorf(ctx, "GitHub API authentication error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v (PAT may be expired or invalid)", req.ProjectId, req.GithubSettingId, err)
+		if isGitHubClientError(err) {
+			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
 			if _, updateErr := c.repository.UpsertDependencySetting(ctx, &code.DependencySettingForUpsert{
 				GithubSettingId:   data.CodeGitHubSettingID,
 				CodeDataSourceId:  data.CodeDataSourceID,
@@ -621,7 +621,7 @@ func (c *CodeService) InvokeScanDependency(ctx context.Context, req *code.Invoke
 				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
 				return nil, fmt.Errorf("failed to update status: %w", updateErr)
 			}
-			return nil, fmt.Errorf("GitHub authentication error: %w", err)
+			return nil, fmt.Errorf("GitHub client error: %w", err)
 		}
 		return nil, err
 	}
@@ -688,9 +688,9 @@ func (c *CodeService) InvokeScanCodeScan(ctx context.Context, req *code.InvokeSc
 	// Get list of repositories filtered by CodeScanSetting (RepositoryPattern, ScanPublic/Internal/Private, etc.)
 	repos, err := c.listCodescanTargetRepository(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
-		// Check if error is authentication error using error type
-		if isGitHubAuthError(err) {
-			c.logger.Errorf(ctx, "GitHub API authentication error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v (PAT may be expired or invalid)", req.ProjectId, req.GithubSettingId, err)
+		// Check if error is GitHub client error (4xx) using error type
+		if isGitHubClientError(err) {
+			c.logger.Errorf(ctx, "GitHub API client error when listing repositories: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
 			// Update status to ERROR with sanitized error message
 			if _, updateErr := c.repository.UpsertCodeScanSetting(ctx, &code.CodeScanSettingForUpsert{
 				GithubSettingId:   data.CodeGitHubSettingID,
@@ -707,8 +707,8 @@ func (c *CodeService) InvokeScanCodeScan(ctx context.Context, req *code.InvokeSc
 				c.logger.Errorf(ctx, "Failed to update status to ERROR: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, updateErr)
 				return nil, fmt.Errorf("failed to update status: %w", updateErr)
 			}
-			// Return authentication error to allow InvokeScanAll to handle it appropriately
-			return nil, fmt.Errorf("GitHub authentication error: %w", err)
+			// Return client error to allow InvokeScanAll to handle it appropriately
+			return nil, fmt.Errorf("GitHub client error: %w", err)
 		}
 		// For other errors, return error as before
 		return nil, err
@@ -790,9 +790,9 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       g.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Check if error is authentication error - continue with other settings
-			if isGitHubAuthError(err) {
-				c.logger.Errorf(ctx, "InvokeScanGitleaks authentication error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
+			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
+			if isGitHubClientError(err) {
+				c.logger.Errorf(ctx, "InvokeScanGitleaks github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
 				continue
 			}
 			c.logger.Errorf(ctx, "InvokeScanGitleaks error occured: code_github_setting_id=%d, err=%+v", g.CodeGitHubSettingID, err)
@@ -819,9 +819,9 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       g.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Check if error is authentication error - continue with other settings
-			if isGitHubAuthError(err) {
-				c.logger.Errorf(ctx, "InvokeScanDependency authentication error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
+			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
+			if isGitHubClientError(err) {
+				c.logger.Errorf(ctx, "InvokeScanDependency github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", g.ProjectID, g.CodeGitHubSettingID, err)
 				continue
 			}
 			c.logger.Errorf(ctx, "InvokeScanDependency error occured: code_github_setting_id=%d, err=%+v", g.CodeGitHubSettingID, err)
@@ -848,9 +848,9 @@ func (c *CodeService) InvokeScanAll(ctx context.Context, _ *empty.Empty) (*empty
 			ProjectId:       codescan.ProjectID,
 			ScanOnly:        true,
 		}); err != nil {
-			// Check if error is authentication error - continue with other settings
-			if isGitHubAuthError(err) {
-				c.logger.Errorf(ctx, "InvokeScanCodeScan authentication error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", codescan.ProjectID, codescan.CodeGitHubSettingID, err)
+			// Skip GitHub 4xx (bad request, auth, not found, etc.) and continue with other settings
+			if isGitHubClientError(err) {
+				c.logger.Errorf(ctx, "InvokeScanCodeScan github client error: project_id=%d, code_github_setting_id=%d, err=%+v (skipping this setting)", codescan.ProjectID, codescan.CodeGitHubSettingID, err)
 				continue
 			}
 			// For all other errors, return error to stop processing

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/aes"
 	"errors"
-	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -1504,6 +1503,9 @@ func TestInvokeScanDependency(t *testing.T) {
 func TestInvokeScanAll(t *testing.T) {
 	now := time.Now()
 	authErr := &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized}}
+	notFoundErr := &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}
+	badRequestErr := &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusBadRequest}}
+	serverErr := &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusInternalServerError}}
 	cases := []struct {
 		name                         string
 		ProjectID                    uint32
@@ -1709,6 +1711,40 @@ func TestInvokeScanAll(t *testing.T) {
 			wantErr:                    false,
 		},
 		{
+			name:      "OK skip gitleaks on github not found error",
+			ProjectID: 1,
+			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse:   &[]model.CodeCodeScanSetting{},
+			mockIsActiveResponse:        &project.IsActiveResponse{Active: true},
+			mockGetGitleaksResponse:     &model.CodeGitleaksSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now,
+			},
+			mockGithubClient: newFakeGithubClient(nil, notFoundErr),
+			mockUpsertGitleaksResponse: &model.CodeGitleaksSetting{},
+			wantErr:         false,
+		},
+		{
+			name:      "OK skip gitleaks on github bad request error",
+			ProjectID: 1,
+			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse:   &[]model.CodeCodeScanSetting{},
+			mockIsActiveResponse:       &project.IsActiveResponse{Active: true},
+			mockGetGitleaksResponse:    &model.CodeGitleaksSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now,
+			},
+			mockGithubClient: newFakeGithubClient(nil, badRequestErr),
+			mockUpsertGitleaksResponse: &model.CodeGitleaksSetting{},
+			wantErr:         false,
+		},
+		{
 			name:                     "NG error InvokeScanDependency",
 			ProjectID:                1,
 			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{},
@@ -1734,6 +1770,80 @@ func TestInvokeScanAll(t *testing.T) {
 			mockGithubClient:             newFakeGithubClient(nil, authErr),
 			mockUpsertDependencyResponse: &model.CodeDependencySetting{},
 			wantErr:                      false,
+		},
+		{
+			name:                     "OK skip dependency on github not found error",
+			ProjectID:                1,
+			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockListCodeScanResponse:     &[]model.CodeCodeScanSetting{},
+			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
+			mockGetDependencyResponse:    &model.CodeDependencySetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
+			mockGithubClient:             newFakeGithubClient(nil, notFoundErr),
+			mockUpsertDependencyResponse: &model.CodeDependencySetting{},
+			wantErr:                      false,
+		},
+		{
+			name:                     "OK skip dependency on github bad request error",
+			ProjectID:                1,
+			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockListCodeScanResponse:     &[]model.CodeCodeScanSetting{},
+			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
+			mockGetDependencyResponse:    &model.CodeDependencySetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
+			mockGithubClient:             newFakeGithubClient(nil, badRequestErr),
+			mockUpsertDependencyResponse: &model.CodeDependencySetting{},
+			wantErr:                      false,
+		},
+		{
+			name:                       "OK skip codescan on github not found error",
+			ProjectID:                  1,
+			mockListGitleaksResponse:   &[]model.CodeGitleaksSetting{},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse: &[]model.CodeCodeScanSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
+			mockGetCodeScanResponse:      &model.CodeCodeScanSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
+			mockGithubClient:             newFakeGithubClient(nil, notFoundErr),
+			mockUpsertCodeScanResponse:   &model.CodeCodeScanSetting{},
+			wantErr:                      false,
+		},
+		{
+			name:                       "OK skip codescan on github bad request error",
+			ProjectID:                  1,
+			mockListGitleaksResponse:   &[]model.CodeGitleaksSetting{},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse: &[]model.CodeCodeScanSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
+			mockGetCodeScanResponse:      &model.CodeCodeScanSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
+			mockGithubClient:             newFakeGithubClient(nil, badRequestErr),
+			mockUpsertCodeScanResponse:   &model.CodeCodeScanSetting{},
+			wantErr:                      false,
+		},
+		{
+			name:                       "NG stop codescan on github server error",
+			ProjectID:                  1,
+			mockListGitleaksResponse:   &[]model.CodeGitleaksSetting{},
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse: &[]model.CodeCodeScanSetting{
+				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			},
+			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
+			mockGetCodeScanResponse:      &model.CodeCodeScanSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
+			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
+			mockGithubClient:             newFakeGithubClient(nil, serverErr),
+			wantErr:                      true,
 		},
 		{
 			name:                       "NG error GetCodeScan",
@@ -1878,108 +1988,4 @@ func (g *FakeGithubClient) Clone(ctx context.Context, token string, cloneURL str
 	return g.err
 }
 
-func TestIsGitHubAuthError(t *testing.T) {
-	cases := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "non-GitHub error",
-			err:      errors.New("some other error"),
-			expected: false,
-		},
-		{
-			name: "GitHub authentication error (401)",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusUnauthorized,
-				},
-				Message: "Bad credentials",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 404 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusNotFound,
-				},
-				Message: "Not Found",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub error with 403 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusForbidden,
-				},
-				Message: "Forbidden",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub error with 500 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusInternalServerError,
-				},
-				Message: "Internal Server Error",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub ErrorResponse with nil Response",
-			err: &ghub.ErrorResponse{
-				Response: nil,
-				Message:  "Some error",
-			},
-			expected: false,
-		},
-		{
-			name: "wrapped GitHub authentication error",
-			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusUnauthorized,
-				},
-				Message: "Bad credentials",
-			}),
-			expected: true,
-		},
-		{
-			name: "wrapped GitHub error with 404 status",
-			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusNotFound,
-				},
-				Message: "Not Found",
-			}),
-			expected: false,
-		},
-		{
-			name: "double wrapped GitHub authentication error",
-			err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusUnauthorized,
-				},
-				Message: "Bad credentials",
-			})),
-			expected: true,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := isGitHubAuthError(c.err)
-			if got != c.expected {
-				t.Errorf("isGitHubAuthError(%v) = %v, want %v", c.err, got, c.expected)
-			}
-		})
-	}
-}
+// NOTE: isGitHubAuthError was removed; 4xx handling is unified via isGitHubClientError.

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/aes"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -1986,6 +1987,152 @@ func (g *FakeGithubClient) ListRepository(ctx context.Context, config *code.GitH
 
 func (g *FakeGithubClient) Clone(ctx context.Context, token string, cloneURL string, dstDir string) error {
 	return g.err
+}
+
+func TestIsGitHubClientError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-GitHub error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name: "GitHub error with 399 status (boundary: below 400)",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 399,
+				},
+				Message: "Client Error",
+			},
+			expected: false,
+		},
+		{
+			name: "GitHub error with 400 status (boundary: start of 4xx)",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusBadRequest,
+				},
+				Message: "Bad Request",
+			},
+			expected: true,
+		},
+		{
+			name: "GitHub error with 401 status",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusUnauthorized,
+				},
+				Message: "Unauthorized",
+			},
+			expected: true,
+		},
+		{
+			name: "GitHub error with 403 status",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusForbidden,
+				},
+				Message: "Forbidden",
+			},
+			expected: true,
+		},
+		{
+			name: "GitHub error with 404 status",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+				},
+				Message: "Not Found",
+			},
+			expected: true,
+		},
+		{
+			name: "GitHub error with 499 status (boundary: end of 4xx)",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: 499,
+				},
+				Message: "Client Closed Request",
+			},
+			expected: true,
+		},
+		{
+			name: "GitHub error with 500 status (boundary: start of 5xx)",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusInternalServerError,
+				},
+				Message: "Internal Server Error",
+			},
+			expected: false,
+		},
+		{
+			name: "GitHub error with 502 status",
+			err: &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusBadGateway,
+				},
+				Message: "Bad Gateway",
+			},
+			expected: false,
+		},
+		{
+			name: "GitHub ErrorResponse with nil Response",
+			err: &ghub.ErrorResponse{
+				Response: nil,
+				Message:  "Some error",
+			},
+			expected: false,
+		},
+		{
+			name: "wrapped GitHub error with 400 status",
+			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusBadRequest,
+				},
+				Message: "Bad Request",
+			}),
+			expected: true,
+		},
+		{
+			name: "wrapped GitHub error with 500 status",
+			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusInternalServerError,
+				},
+				Message: "Internal Server Error",
+			}),
+			expected: false,
+		},
+		{
+			name: "double wrapped GitHub error with 404 status",
+			err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &ghub.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+				},
+				Message: "Not Found",
+			})),
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isGitHubClientError(c.err)
+			if got != c.expected {
+				t.Errorf("isGitHubClientError(%v) = %v, want %v", c.err, got, c.expected)
+			}
+		})
+	}
 }
 
 // NOTE: isGitHubAuthError was removed; 4xx handling is unified via isGitHubClientError.

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/aes"
 	"errors"
-	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -1685,14 +1684,16 @@ func TestInvokeScanAll(t *testing.T) {
 			wantErr:           true,
 		},
 		{
-			name:      "NG error InvokeScanGitleaks",
-			ProjectID: 1,
+			name:                     "OK skip gitleaks on InvokeScanGitleaks error",
+			ProjectID:                1,
 			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{
 				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
 			},
-			mockIsActiveResponse: &project.IsActiveResponse{Active: true},
-			mockGetGitleaksError: gorm.ErrInvalidDB,
-			wantErr:              true,
+			mockListDependencyResponse: &[]model.CodeDependencySetting{},
+			mockListCodeScanResponse:   &[]model.CodeCodeScanSetting{},
+			mockIsActiveResponse:       &project.IsActiveResponse{Active: true},
+			mockGetGitleaksError:       gorm.ErrInvalidDB,
+			wantErr:                    false,
 		},
 		{
 			name:      "OK skip gitleaks on github auth error",
@@ -1746,16 +1747,17 @@ func TestInvokeScanAll(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name:                     "NG error InvokeScanDependency",
+			name:                     "OK skip dependency on InvokeScanDependency error",
 			ProjectID:                1,
 			mockListGitleaksResponse: &[]model.CodeGitleaksSetting{},
 			mockListDependencyResponse: &[]model.CodeDependencySetting{
 				{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
 			},
+			mockListCodeScanResponse:     &[]model.CodeCodeScanSetting{},
 			mockIsActiveResponse:         &project.IsActiveResponse{Active: true},
 			mockGetDependencyError:       gorm.ErrInvalidDB,
 			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
-			wantErr:                      true,
+			wantErr:                      false,
 		},
 		{
 			name:                     "OK skip dependency on github auth error",
@@ -1833,7 +1835,7 @@ func TestInvokeScanAll(t *testing.T) {
 			wantErr:                      false,
 		},
 		{
-			name:                       "NG stop codescan on github server error",
+			name:                       "OK skip codescan on github server error",
 			ProjectID:                  1,
 			mockListGitleaksResponse:   &[]model.CodeGitleaksSetting{},
 			mockListDependencyResponse: &[]model.CodeDependencySetting{},
@@ -1844,10 +1846,11 @@ func TestInvokeScanAll(t *testing.T) {
 			mockGetCodeScanResponse:      &model.CodeCodeScanSetting{CodeGitHubSettingID: 1, CodeDataSourceID: 1, ProjectID: 1, Status: "OK", StatusDetail: "", ScanAt: now, CreatedAt: now, UpdatedAt: now},
 			mockGetGitHubSettingResponse: &model.CodeGitHubSetting{CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "ca-risken", GitHubUser: "user", PersonalAccessToken: "", CreatedAt: now, UpdatedAt: now},
 			mockGithubClient:             newFakeGithubClient(nil, serverErr),
-			wantErr:                      true,
+			mockUpsertCodeScanResponse:   &model.CodeCodeScanSetting{},
+			wantErr:                      false,
 		},
 		{
-			name:                       "NG error GetCodeScan",
+			name:                       "OK skip codescan on GetCodeScan error",
 			ProjectID:                  1,
 			mockListGitleaksResponse:   &[]model.CodeGitleaksSetting{},
 			mockListDependencyResponse: &[]model.CodeDependencySetting{},
@@ -1856,7 +1859,7 @@ func TestInvokeScanAll(t *testing.T) {
 			},
 			mockIsActiveResponse: &project.IsActiveResponse{Active: true},
 			mockGetCodeScanError: gorm.ErrInvalidDB,
-			wantErr:              true, // If GetCodeScanSetting returns an error, InvokeScanCodeScan returns an error
+			wantErr:              false,
 		},
 	}
 	for _, c := range cases {
@@ -1989,150 +1992,3 @@ func (g *FakeGithubClient) Clone(ctx context.Context, token string, cloneURL str
 	return g.err
 }
 
-func TestIsGitHubClientError(t *testing.T) {
-	cases := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "non-GitHub error",
-			err:      errors.New("some other error"),
-			expected: false,
-		},
-		{
-			name: "GitHub error with 399 status (boundary: below 400)",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: 399,
-				},
-				Message: "Client Error",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub error with 400 status (boundary: start of 4xx)",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusBadRequest,
-				},
-				Message: "Bad Request",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 401 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusUnauthorized,
-				},
-				Message: "Unauthorized",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 403 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusForbidden,
-				},
-				Message: "Forbidden",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 404 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusNotFound,
-				},
-				Message: "Not Found",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 499 status (boundary: end of 4xx)",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: 499,
-				},
-				Message: "Client Closed Request",
-			},
-			expected: true,
-		},
-		{
-			name: "GitHub error with 500 status (boundary: start of 5xx)",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusInternalServerError,
-				},
-				Message: "Internal Server Error",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub error with 502 status",
-			err: &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusBadGateway,
-				},
-				Message: "Bad Gateway",
-			},
-			expected: false,
-		},
-		{
-			name: "GitHub ErrorResponse with nil Response",
-			err: &ghub.ErrorResponse{
-				Response: nil,
-				Message:  "Some error",
-			},
-			expected: false,
-		},
-		{
-			name: "wrapped GitHub error with 400 status",
-			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusBadRequest,
-				},
-				Message: "Bad Request",
-			}),
-			expected: true,
-		},
-		{
-			name: "wrapped GitHub error with 500 status",
-			err: fmt.Errorf("wrapped error: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusInternalServerError,
-				},
-				Message: "Internal Server Error",
-			}),
-			expected: false,
-		},
-		{
-			name: "double wrapped GitHub error with 404 status",
-			err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &ghub.ErrorResponse{
-				Response: &http.Response{
-					StatusCode: http.StatusNotFound,
-				},
-				Message: "Not Found",
-			})),
-			expected: true,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := isGitHubClientError(c.err)
-			if got != c.expected {
-				t.Errorf("isGitHubClientError(%v) = %v, want %v", c.err, got, c.expected)
-			}
-		})
-	}
-}
-
-// NOTE: isGitHubAuthError was removed; 4xx handling is unified via isGitHubClientError.


### PR DESCRIPTION
GitHubのクライアント系のエラーは一本化して、InvokeScanAll()の処理が継続するよう修正