### PR TITLE
[update]upsert process

### DIFF
--- a/pkg/attackflow/aws/aws_s3.go
+++ b/pkg/attackflow/aws/aws_s3.go
@@ -115,7 +115,7 @@ func (s *s3Analyzer) Analyze(ctx context.Context, resp *datasource.AnalyzeAttack
 		s.metadata.Encryption = fmt.Sprint(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
 		break
 	}
-	s.metadata.IsPublic = policyStatus.PolicyStatus != nil && policyStatus.PolicyStatus.IsPublic
+	s.metadata.IsPublic = policyStatus.PolicyStatus != nil && aws.ToBool(policyStatus.PolicyStatus.IsPublic)
 	s.metadata.Versioning = versioning.Status == types.BucketVersioningStatusEnabled
 	for _, config := range notification.LambdaFunctionConfigurations {
 		s.metadata.LambdaConfiguration = append(s.metadata.LambdaConfiguration, aws.ToString(config.LambdaFunctionArn))

--- a/pkg/attackflow/aws/aws_s3.go
+++ b/pkg/attackflow/aws/aws_s3.go
@@ -115,7 +115,7 @@ func (s *s3Analyzer) Analyze(ctx context.Context, resp *datasource.AnalyzeAttack
 		s.metadata.Encryption = fmt.Sprint(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
 		break
 	}
-	s.metadata.IsPublic = policyStatus.PolicyStatus != nil && aws.ToBool(policyStatus.PolicyStatus.IsPublic)
+	s.metadata.IsPublic = policyStatus.PolicyStatus != nil && policyStatus.PolicyStatus.IsPublic
 	s.metadata.Versioning = versioning.Status == types.BucketVersioningStatusEnabled
 	for _, config := range notification.LambdaFunctionConfigurations {
 		s.metadata.LambdaConfiguration = append(s.metadata.LambdaConfiguration, aws.ToString(config.LambdaFunctionArn))

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -117,10 +117,30 @@ func (c *Client) GetGitHubSetting(ctx context.Context, projectID uint32, githubS
 }
 
 func (c *Client) UpsertGitHubSetting(ctx context.Context, data *code.GitHubSettingForUpsert) (*model.CodeGitHubSetting, error) {
+	if data.AuthMode == code.GitHubAuthModeGitHubApp {
+		return c.UpsertGitHubAppSetting(ctx, data)
+	}
+	if data.AuthMode == code.GitHubAuthModePersonalAccessToken {
+		return c.UpsertGitHubPATSetting(ctx, data)
+	}
 	if data.PersonalAccessToken != "" {
 		return c.UpsertGitHubSettingWithToken(ctx, data)
 	}
 	return c.UpsertGitHubSettingWithoutToken(ctx, data)
+}
+
+func convertInstallationIDToNull(installationID uint64) interface{} {
+	if installationID == 0 {
+		return nil
+	}
+	return installationID
+}
+
+func convertPersonalAccessTokenToNil(personalAccessToken string) interface{} {
+	if personalAccessToken == "" {
+		return nil
+	}
+	return personalAccessToken
 }
 
 const upsertGitHubWithToken = `
@@ -161,6 +181,50 @@ func (c *Client) UpsertGitHubSettingWithToken(ctx context.Context, data *code.Gi
 	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
 }
 
+const upsertGitHubAppAuth = `
+INSERT INTO code_github_setting (
+  code_github_setting_id,
+  name,
+  project_id,
+  type,
+  base_url,
+  target_resource,
+  github_user,
+  personal_access_token,
+  installation_id,
+  auth_mode
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	code_github_setting_id=VALUES(code_github_setting_id),
+	name=VALUES(name),
+	project_id=VALUES(project_id),
+	type=VALUES(type),
+	base_url=VALUES(base_url),
+	target_resource=VALUES(target_resource),
+	github_user=VALUES(github_user),
+	personal_access_token=VALUES(personal_access_token),
+	installation_id=VALUES(installation_id),
+	auth_mode=VALUES(auth_mode)
+`
+
+func (c *Client) UpsertGitHubAppSetting(ctx context.Context, data *code.GitHubSettingForUpsert) (*model.CodeGitHubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGitHubAppAuth,
+		data.GithubSettingId,
+		convertZeroValueToNull(data.Name),
+		data.ProjectId,
+		data.Type.String(),
+		data.BaseUrl,
+		data.TargetResource,
+		convertZeroValueToNull(data.GithubUser),
+		nil,
+		convertInstallationIDToNull(data.InstallationId),
+		data.AuthMode).Error; err != nil {
+		return nil, err
+	}
+	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
+}
+
 const upsertGitHubSettingWithoutToken = `
 INSERT INTO code_github_setting (
   code_github_setting_id,
@@ -191,6 +255,50 @@ func (c *Client) UpsertGitHubSettingWithoutToken(ctx context.Context, data *code
 		data.BaseUrl,
 		data.TargetResource,
 		convertZeroValueToNull(data.GithubUser)).Error; err != nil {
+		return nil, err
+	}
+	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)
+}
+
+const upsertGitHubPATAuth = `
+INSERT INTO code_github_setting (
+  code_github_setting_id,
+  name,
+  project_id,
+  type,
+  base_url,
+  target_resource,
+  github_user,
+  personal_access_token,
+  installation_id,
+  auth_mode
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON DUPLICATE KEY UPDATE
+	code_github_setting_id=VALUES(code_github_setting_id),
+	name=VALUES(name),
+	project_id=VALUES(project_id),
+	type=VALUES(type),
+	base_url=VALUES(base_url),
+	target_resource=VALUES(target_resource),
+	github_user=VALUES(github_user),
+	personal_access_token=IF(VALUES(personal_access_token) IS NULL, personal_access_token, VALUES(personal_access_token)),
+	installation_id=VALUES(installation_id),
+	auth_mode=VALUES(auth_mode)
+`
+
+func (c *Client) UpsertGitHubPATSetting(ctx context.Context, data *code.GitHubSettingForUpsert) (*model.CodeGitHubSetting, error) {
+	if err := c.MasterDB.WithContext(ctx).Exec(upsertGitHubPATAuth,
+		data.GithubSettingId,
+		convertZeroValueToNull(data.Name),
+		data.ProjectId,
+		data.Type.String(),
+		data.BaseUrl,
+		data.TargetResource,
+		convertZeroValueToNull(data.GithubUser),
+		convertPersonalAccessTokenToNil(data.PersonalAccessToken),
+		nil,
+		data.AuthMode).Error; err != nil {
 		return nil, err
 	}
 	return c.GetGitHubSettingByUniqueIndex(ctx, data.ProjectId, data.Name)

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -129,13 +129,6 @@ func (c *Client) UpsertGitHubSetting(ctx context.Context, data *code.GitHubSetti
 	return c.UpsertGitHubSettingWithoutToken(ctx, data)
 }
 
-func convertInstallationIDToNull(installationID uint64) any {
-	if installationID == 0 {
-		return nil
-	}
-	return installationID
-}
-
 const upsertGitHubWithToken = `
 INSERT INTO code_github_setting (
   code_github_setting_id,
@@ -211,7 +204,7 @@ func (c *Client) UpsertGitHubAppSetting(ctx context.Context, data *code.GitHubSe
 		data.TargetResource,
 		convertZeroValueToNull(data.GithubUser),
 		nil,
-		convertInstallationIDToNull(data.InstallationId),
+		convertZeroValueToNull(data.InstallationId),
 		data.AuthMode).Error; err != nil {
 		return nil, err
 	}

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -129,14 +129,14 @@ func (c *Client) UpsertGitHubSetting(ctx context.Context, data *code.GitHubSetti
 	return c.UpsertGitHubSettingWithoutToken(ctx, data)
 }
 
-func convertInstallationIDToNull(installationID uint64) interface{} {
+func convertInstallationIDToNull(installationID uint64) any {
 	if installationID == 0 {
 		return nil
 	}
 	return installationID
 }
 
-func convertPersonalAccessTokenToNil(personalAccessToken string) interface{} {
+func convertPersonalAccessTokenToNil(personalAccessToken string) any {
 	if personalAccessToken == "" {
 		return nil
 	}

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -136,13 +136,6 @@ func convertInstallationIDToNull(installationID uint64) any {
 	return installationID
 }
 
-func convertPersonalAccessTokenToNil(personalAccessToken string) any {
-	if personalAccessToken == "" {
-		return nil
-	}
-	return personalAccessToken
-}
-
 const upsertGitHubWithToken = `
 INSERT INTO code_github_setting (
   code_github_setting_id,
@@ -296,7 +289,7 @@ func (c *Client) UpsertGitHubPATSetting(ctx context.Context, data *code.GitHubSe
 		data.BaseUrl,
 		data.TargetResource,
 		convertZeroValueToNull(data.GithubUser),
-		convertPersonalAccessTokenToNil(data.PersonalAccessToken),
+		convertZeroValueToNull(data.PersonalAccessToken),
 		nil,
 		data.AuthMode).Error; err != nil {
 		return nil, err

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -1070,8 +1070,7 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(selectCodeScanRepositoryStatusSummary)).
 					WillReturnRows(sqlmock.NewRows(summaryColumns).
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
-					WithArgs(uint32(1), uint32(1), 1).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",
@@ -1125,8 +1124,7 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(selectCodeScanRepositoryStatusSummary)).
 					WillReturnRows(sqlmock.NewRows(summaryColumns).
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
-					WithArgs(uint32(1), uint32(1), 1).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",
@@ -1169,8 +1167,7 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
 				// Step 3: Check current parent - status and status_detail are same, so skip full UPDATE but refresh scan_at
 				parentScanAt := time.Unix(now.Unix(), 0)
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
-					WithArgs(uint32(1), uint32(1), 1).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -163,6 +163,7 @@ func TestGetGitHubSetting(t *testing.T) {
 
 func TestUpsertGitHubSetting(t *testing.T) {
 	now := time.Now()
+	installationID := uint64(12345)
 	type args struct {
 		data *code.GitHubSettingForUpsert
 	}
@@ -186,6 +187,34 @@ func TestUpsertGitHubSetting(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
 					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "personal_access_token", "created_at", "updated_at"}).
 					AddRow(uint32(1), "github_setting1", uint32(1), "ORGANIZATION", "target", "user", "token", now, now))
+			},
+		},
+		{
+			name: "OK github app",
+			args: args{
+				data: &code.GitHubSettingForUpsert{GithubSettingId: 1, Name: "name", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "user", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID},
+			},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "user", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubAppAuth)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "installation_id", "auth_mode", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "ORGANIZATION", "target", "user", installationID, code.GitHubAuthModeGitHubApp, now, now))
+			},
+		},
+		{
+			name: "OK personal access token auth mode",
+			args: args{
+				data: &code.GitHubSettingForUpsert{GithubSettingId: 1, Name: "name", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "user", AuthMode: code.GitHubAuthModePersonalAccessToken},
+			},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token", AuthMode: code.GitHubAuthModePersonalAccessToken, CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubPATAuth)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "personal_access_token", "auth_mode", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "ORGANIZATION", "target", "user", "token", code.GitHubAuthModePersonalAccessToken, now, now))
 			},
 		},
 		{

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -211,7 +212,8 @@ func TestUpsertGitHubSetting(t *testing.T) {
 			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token", AuthMode: code.GitHubAuthModePersonalAccessToken, CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec(regexp.QuoteMeta(upsertGitHubPATAuth)).WillReturnResult(sqlmock.NewResult(1, 1))
+				query := strings.Replace(upsertGitHubPATAuth, "?, ?, ?, ?, ?, ?, ?, ?, ?, ?", "?, ?, ?, ?, ?, ?, ?, NULL, ?, ?", 1)
+				mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
 					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "personal_access_token", "auth_mode", "created_at", "updated_at"}).
 					AddRow(uint32(1), "github_setting1", uint32(1), "ORGANIZATION", "target", "user", "token", code.GitHubAuthModePersonalAccessToken, now, now))

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -1070,7 +1070,8 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(selectCodeScanRepositoryStatusSummary)).
 					WillReturnRows(sqlmock.NewRows(summaryColumns).
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
+					WithArgs(uint32(1), uint32(1), 1).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",
@@ -1124,7 +1125,8 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(selectCodeScanRepositoryStatusSummary)).
 					WillReturnRows(sqlmock.NewRows(summaryColumns).
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
+					WithArgs(uint32(1), uint32(1), 1).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",
@@ -1167,7 +1169,8 @@ func TestUpsertCodeScanRepository(t *testing.T) {
 						AddRow(int64(1), int64(1), int64(0), int64(0), int64(0)))
 				// Step 3: Check current parent - status and status_detail are same, so skip full UPDATE but refresh scan_at
 				parentScanAt := time.Unix(now.Unix(), 0)
-				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT 1")).
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_codescan_setting` WHERE project_id = ? AND code_github_setting_id = ? ORDER BY `code_codescan_setting`.`code_github_setting_id` LIMIT ?")).
+					WithArgs(uint32(1), uint32(1), 1).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "code_data_source_id", "project_id", "repository_pattern",
 						"scan_public", "scan_internal", "scan_private",

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -141,8 +141,17 @@ func convertGitHubSetting(
 		TargetResource:      gitHubSetting.TargetResource,
 		GithubUser:          gitHubSetting.GitHubUser,
 		PersonalAccessToken: gitHubSetting.PersonalAccessToken,
+		AuthMode:            gitHubSetting.AuthMode,
+		VerificationStatus:  gitHubSetting.VerificationStatus,
+		VerifiedGithubUser:  gitHubSetting.VerifiedGitHubUser,
 		CreatedAt:           gitHubSetting.CreatedAt.Unix(),
 		UpdatedAt:           gitHubSetting.UpdatedAt.Unix(),
+	}
+	if gitHubSetting.InstallationID != nil {
+		convertedGithubSetting.InstallationId = *gitHubSetting.InstallationID
+	}
+	if !gitHubSetting.VerifiedAt.IsZero() {
+		convertedGithubSetting.VerifiedAt = gitHubSetting.VerifiedAt.Unix()
 	}
 	if convertedGithubSetting.PersonalAccessToken != "" && maskKey {
 		convertedGithubSetting.PersonalAccessToken = maskData // Masking sensitive data.

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -451,6 +451,8 @@ func TestGetGitHubSetting(t *testing.T) {
 
 func TestPutGitHubSetting(t *testing.T) {
 	now := time.Now()
+	verifiedAt := now.Add(-time.Hour)
+	installationID := uint64(12345)
 	key := []byte("1234567890123456")
 	block, err := aes.NewCipher(key)
 	assert.NoError(t, err)
@@ -472,6 +474,18 @@ func TestPutGitHubSetting(t *testing.T) {
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "user", PersonalAccessToken: "token", CreatedAt: now, UpdatedAt: now,
+			},
+		},
+		{
+			name: "OK github app",
+			input: &code.PutGitHubSettingRequest{ProjectId: 1, GithubSetting: &code.GitHubSettingForUpsert{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID},
+			},
+			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "VERIFIED", VerifiedGithubUser: "octocat", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+			},
+			mockResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: "VERIFIED", VerifiedGitHubUser: "octocat", VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 		},
 		{


### PR DESCRIPTION
- `GitHubSetting` レスポンスに以下のフィールドを反映
  - `auth_mode`
  - `installation_id`
  - `verification_status`
  - `verified_github_user`
  - `verified_at`
- `auth_mode = GITHUB_APP` のUpsert時に以下を保存
  - `auth_mode`
  - `installation_id`
  - `personal_access_token = NULL`
- `auth_mode = PERSONAL_ACCESS_TOKEN` のUpsert時に以下を保存
  - `auth_mode`
  - `installation_id = NULL`
  - `personal_access_token` は未指定なら既存値を維持
- `auth_mode` 未指定時は既存のPAT保存処理を維持