### PR TITLE
[add]issue-githubapp-installation-token

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,14 +60,15 @@ type AppConf struct {
 	AzureProwlerQueueURL             string `split_words:"true" required:"true" default:"http://queue.middleware.svc.cluster.local:9324/queue/azure-prowler"`
 
 	// datasource
-	GoogleCredentialPath string `required:"true" split_words:"true" default:"/tmp/credential.json"` // google
-	CodeDataKey          string `split_words:"true" required:"true"`                                // code
-	GithubAppID          string `split_words:"true"`                                                // code
-	GithubAppPrivateKey  string `split_words:"true"`                                                // code
-	SlackAPIToken        string `split_words:"true"`                                                // slack
-	AzureClientID        string `split_words:"true"`                                                // azure
-	AzureTenantID        string `split_words:"true"`                                                // azure
-	AzureClientSecret    string `split_words:"true"`                                                // azure
+	GoogleCredentialPath         string   `required:"true" split_words:"true" default:"/tmp/credential.json"` // google
+	CodeDataKey                  string   `split_words:"true" required:"true"`                                // code
+	GithubAppID                  string   `split_words:"true"`                                                // code
+	GithubAppPrivateKey          string   `split_words:"true"`                                                // code
+	GithubAppAllowedBaseURLHosts []string `split_words:"true"`                                                // code
+	SlackAPIToken                string   `split_words:"true"`                                                // slack
+	AzureClientID                string   `split_words:"true"`                                                // azure
+	AzureTenantID                string   `split_words:"true"`                                                // azure
+	AzureClientSecret            string   `split_words:"true"`                                                // azure
 
 	// db
 	DBMasterHost     string `split_words:"true" default:"db.middleware.svc.cluster.local"`
@@ -177,8 +178,9 @@ func main() {
 		conf.GoogleCredentialPath,
 		conf.CodeDataKey,
 		&github.AppAuthConfig{
-			AppID:      conf.GithubAppID,
-			PrivateKey: conf.GithubAppPrivateKey,
+			AppID:               conf.GithubAppID,
+			PrivateKey:          conf.GithubAppPrivateKey,
+			AllowedBaseURLHosts: conf.GithubAppAllowedBaseURLHosts,
 		},
 		d,
 		q,

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ca-risken/common/pkg/profiler"
 	"github.com/ca-risken/common/pkg/tracer"
 	"github.com/ca-risken/datasource-api/pkg/db"
+	"github.com/ca-risken/datasource-api/pkg/github"
 	"github.com/ca-risken/datasource-api/pkg/queue"
 	"github.com/ca-risken/datasource-api/pkg/server"
 	"github.com/gassara-kys/envconfig"
@@ -61,6 +62,8 @@ type AppConf struct {
 	// datasource
 	GoogleCredentialPath string `required:"true" split_words:"true" default:"/tmp/credential.json"` // google
 	CodeDataKey          string `split_words:"true" required:"true"`                                // code
+	GithubAppID          string `split_words:"true"`                                                // code
+	GithubAppPrivateKey  string `split_words:"true"`                                                // code
 	SlackAPIToken        string `split_words:"true"`                                                // slack
 	AzureClientID        string `split_words:"true"`                                                // azure
 	AzureTenantID        string `split_words:"true"`                                                // azure
@@ -173,6 +176,10 @@ func main() {
 		conf.AWSRegion,
 		conf.GoogleCredentialPath,
 		conf.CodeDataKey,
+		&github.AppAuthConfig{
+			AppID:      conf.GithubAppID,
+			PrivateKey: conf.GithubAppPrivateKey,
+		},
 		d,
 		q,
 		conf.BaseURL,

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -22,7 +22,7 @@ const (
 	githubAppJWTLifetime = 9 * time.Minute
 )
 
-var githubAppAllowedBaseURLHosts = map[string]struct{}{
+var defaultGitHubAppAllowedBaseURLHosts = map[string]struct{}{
 	"api.github.com": {},
 }
 
@@ -32,13 +32,15 @@ var newGitHubAppHTTPClient = func(ctx context.Context, token *oauth2.Token) *htt
 
 // AppAuthConfig is the server-side GitHub App credential set.
 type AppAuthConfig struct {
-	AppID      string
-	PrivateKey string
+	AppID               string
+	PrivateKey          string
+	AllowedBaseURLHosts []string
 }
 
 type appAuth struct {
-	appID      int64
-	privateKey *rsa.PrivateKey
+	appID               int64
+	privateKey          *rsa.PrivateKey
+	allowedBaseURLHosts map[string]struct{}
 }
 
 func newAppAuth(conf *AppAuthConfig) (*appAuth, error) {
@@ -57,9 +59,25 @@ func newAppAuth(conf *AppAuthConfig) (*appAuth, error) {
 		return nil, fmt.Errorf("parse github app private key: %w", err)
 	}
 	return &appAuth{
-		appID:      appID,
-		privateKey: privateKey,
+		appID:               appID,
+		privateKey:          privateKey,
+		allowedBaseURLHosts: allowedGitHubAppBaseURLHosts(conf.AllowedBaseURLHosts),
 	}, nil
+}
+
+func allowedGitHubAppBaseURLHosts(configuredHosts []string) map[string]struct{} {
+	allowedHosts := make(map[string]struct{}, len(defaultGitHubAppAllowedBaseURLHosts)+len(configuredHosts))
+	for host := range defaultGitHubAppAllowedBaseURLHosts {
+		allowedHosts[host] = struct{}{}
+	}
+	for _, host := range configuredHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized == "" {
+			continue
+		}
+		allowedHosts[normalized] = struct{}{}
+	}
+	return allowedHosts
 }
 
 func parseGitHubAppPrivateKey(privateKey string) (*rsa.PrivateKey, error) {
@@ -89,7 +107,7 @@ func (g *riskenGitHubClient) createGitHubAppJWT(now time.Time) (string, error) {
 }
 
 func (g *riskenGitHubClient) newGitHubAppClient(ctx context.Context, baseURL string) (*ghub.Client, error) {
-	base, err := validateGitHubAppBaseURL(baseURL)
+	base, err := g.appAuth.validateBaseURL(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +123,7 @@ func (g *riskenGitHubClient) newGitHubAppClient(ctx context.Context, baseURL str
 	return client, nil
 }
 
-func validateGitHubAppBaseURL(baseURL string) (*url.URL, error) {
+func (a *appAuth) validateBaseURL(baseURL string) (*url.URL, error) {
 	if baseURL == "" {
 		return nil, nil
 	}
@@ -116,7 +134,7 @@ func validateGitHubAppBaseURL(baseURL string) (*url.URL, error) {
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("github app base_url must use https: %s", baseURL)
 	}
-	if _, ok := githubAppAllowedBaseURLHosts[strings.ToLower(u.Hostname())]; !ok {
+	if _, ok := a.allowedBaseURLHosts[strings.ToLower(u.Hostname())]; !ok {
 		return nil, fmt.Errorf("github app base_url host is not allowed: %s", u.Hostname())
 	}
 	return u, nil

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -137,6 +137,9 @@ func (a *appAuth) validateBaseURL(baseURL string) (*url.URL, error) {
 	if _, ok := a.allowedBaseURLHosts[strings.ToLower(u.Hostname())]; !ok {
 		return nil, fmt.Errorf("github app base_url host is not allowed: %s", u.Hostname())
 	}
+	if u.Path == "" || !strings.HasSuffix(u.Path, "/") {
+		u.Path += "/"
+	}
 	return u, nil
 }
 
@@ -154,7 +157,10 @@ func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, confi
 	if err != nil {
 		return "", fmt.Errorf("create github app client: %w", err)
 	}
-	opts := installationTokenOptions(repoName)
+	opts, err := installationTokenOptions(repoName)
+	if err != nil {
+		return "", err
+	}
 	token, _, err := client.Apps.CreateInstallationToken(ctx, int64(config.InstallationId), opts)
 	if err != nil {
 		return "", fmt.Errorf("create installation token: %w", err)
@@ -165,15 +171,26 @@ func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, confi
 	return token.GetToken(), nil
 }
 
-func installationTokenOptions(repoName string) *ghub.InstallationTokenOptions {
+func installationTokenOptions(repoName string) (*ghub.InstallationTokenOptions, error) {
+	repoName = strings.TrimSpace(repoName)
 	if repoName == "" {
-		return nil
+		return nil, nil
 	}
 	parts := strings.Split(repoName, "/")
-	if len(parts) == 2 {
+	switch len(parts) {
+	case 1:
+		if parts[0] == "" {
+			return nil, fmt.Errorf("invalid repository name: %s", repoName)
+		}
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid repository full name: %s", repoName)
+		}
 		repoName = parts[1]
+	default:
+		return nil, fmt.Errorf("invalid repository full name: %s", repoName)
 	}
 	return &ghub.InstallationTokenOptions{
 		Repositories: []string{repoName},
-	}
+	}, nil
 }

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -20,6 +21,14 @@ const (
 	githubAppJWTBackdate = time.Minute
 	githubAppJWTLifetime = 9 * time.Minute
 )
+
+var githubAppAllowedBaseURLHosts = map[string]struct{}{
+	"api.github.com": {},
+}
+
+var newGitHubAppHTTPClient = func(ctx context.Context, token *oauth2.Token) *http.Client {
+	return oauth2.NewClient(ctx, oauth2.StaticTokenSource(token))
+}
 
 // AppAuthConfig is the server-side GitHub App credential set.
 type AppAuthConfig struct {
@@ -80,22 +89,37 @@ func (g *riskenGitHubClient) createGitHubAppJWT(now time.Time) (string, error) {
 }
 
 func (g *riskenGitHubClient) newGitHubAppClient(ctx context.Context, baseURL string) (*ghub.Client, error) {
+	base, err := validateGitHubAppBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
 	jwtToken, err := g.createGitHubAppJWT(time.Now())
 	if err != nil {
 		return nil, err
 	}
-	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: jwtToken, TokenType: "Bearer"},
-	))
+	httpClient := newGitHubAppHTTPClient(ctx, &oauth2.Token{AccessToken: jwtToken, TokenType: "Bearer"})
 	client := ghub.NewClient(httpClient)
-	if baseURL != "" {
-		u, err := url.Parse(baseURL)
-		if err != nil {
-			return nil, err
-		}
-		client.BaseURL = u
+	if base != nil {
+		client.BaseURL = base
 	}
 	return client, nil
+}
+
+func validateGitHubAppBaseURL(baseURL string) (*url.URL, error) {
+	if baseURL == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("github app base_url must use https: %s", baseURL)
+	}
+	if _, ok := githubAppAllowedBaseURLHosts[strings.ToLower(u.Hostname())]; !ok {
+		return nil, fmt.Errorf("github app base_url host is not allowed: %s", u.Hostname())
+	}
+	return u, nil
 }
 
 func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -1,0 +1,137 @@
+package github
+
+import (
+	"context"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ca-risken/datasource-api/proto/code"
+	jwt "github.com/golang-jwt/jwt/v5"
+	ghub "github.com/google/go-github/v44/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	githubAppJWTBackdate = time.Minute
+	githubAppJWTLifetime = 9 * time.Minute
+)
+
+// AppAuthConfig is the server-side GitHub App credential set.
+type AppAuthConfig struct {
+	AppID      string
+	PrivateKey string
+}
+
+type appAuth struct {
+	appID      int64
+	privateKey *rsa.PrivateKey
+}
+
+func newAppAuth(conf *AppAuthConfig) (*appAuth, error) {
+	if conf == nil || (conf.AppID == "" && conf.PrivateKey == "") {
+		return nil, nil
+	}
+	if conf.AppID == "" || conf.PrivateKey == "" {
+		return nil, errors.New("github app id and private key are required together")
+	}
+	appID, err := strconv.ParseInt(conf.AppID, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse github app id: %w", err)
+	}
+	privateKey, err := parseGitHubAppPrivateKey(conf.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse github app private key: %w", err)
+	}
+	return &appAuth{
+		appID:      appID,
+		privateKey: privateKey,
+	}, nil
+}
+
+func parseGitHubAppPrivateKey(privateKey string) (*rsa.PrivateKey, error) {
+	normalized := strings.ReplaceAll(privateKey, `\n`, "\n")
+	return jwt.ParseRSAPrivateKeyFromPEM([]byte(normalized))
+}
+
+func (g *riskenGitHubClient) SupportsGitHubApp() bool {
+	return g.appAuth != nil
+}
+
+func (g *riskenGitHubClient) createGitHubAppJWT(now time.Time) (string, error) {
+	if g.appAuth == nil {
+		return "", errors.New("github app auth is not configured")
+	}
+	claims := jwt.RegisteredClaims{
+		Issuer:    strconv.FormatInt(g.appAuth.appID, 10),
+		IssuedAt:  jwt.NewNumericDate(now.Add(-githubAppJWTBackdate)),
+		ExpiresAt: jwt.NewNumericDate(now.Add(githubAppJWTLifetime)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(g.appAuth.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("sign github app jwt: %w", err)
+	}
+	return signed, nil
+}
+
+func (g *riskenGitHubClient) newGitHubAppClient(ctx context.Context, baseURL string) (*ghub.Client, error) {
+	jwtToken, err := g.createGitHubAppJWT(time.Now())
+	if err != nil {
+		return nil, err
+	}
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: jwtToken, TokenType: "Bearer"},
+	))
+	client := ghub.NewClient(httpClient)
+	if baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, err
+		}
+		client.BaseURL = u
+	}
+	return client, nil
+}
+
+func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {
+	if g.appAuth == nil {
+		return "", errors.New("github app auth is not configured")
+	}
+	if config == nil {
+		return "", errors.New("github setting is required")
+	}
+	if config.InstallationId == 0 {
+		return "", errors.New("installation_id is required")
+	}
+	client, err := g.newGitHubAppClient(ctx, config.BaseUrl)
+	if err != nil {
+		return "", fmt.Errorf("create github app client: %w", err)
+	}
+	opts := installationTokenOptions(repoName)
+	token, _, err := client.Apps.CreateInstallationToken(ctx, int64(config.InstallationId), opts)
+	if err != nil {
+		return "", fmt.Errorf("create installation token: %w", err)
+	}
+	if token.GetToken() == "" {
+		return "", errors.New("installation token is empty")
+	}
+	return token.GetToken(), nil
+}
+
+func installationTokenOptions(repoName string) *ghub.InstallationTokenOptions {
+	if repoName == "" {
+		return nil
+	}
+	parts := strings.Split(repoName, "/")
+	if len(parts) == 2 {
+		repoName = parts[1]
+	}
+	return &ghub.InstallationTokenOptions{
+		Repositories: []string{repoName},
+	}
+}

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/datasource-api/proto/code"
 	jwt "github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
 )
 
 func generateRSAPrivateKeyPEM(t *testing.T) (*rsa.PrivateKey, string) {
@@ -159,7 +161,7 @@ func TestResolveInstallationToken(t *testing.T) {
 	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
 	var gotAuthorization string
 	var gotRepositories []string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/app/installations/12345/access_tokens" {
 			t.Fatalf("Unexpected path: %s", r.URL.Path)
 		}
@@ -180,6 +182,24 @@ func TestResolveInstallationToken(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	githubAppAllowedBaseURLHosts[serverURL.Hostname()] = struct{}{}
+	defer delete(githubAppAllowedBaseURLHosts, serverURL.Hostname())
+	origNewGitHubAppHTTPClient := newGitHubAppHTTPClient
+	newGitHubAppHTTPClient = func(ctx context.Context, token *oauth2.Token) *http.Client {
+		client := server.Client()
+		client.Transport = &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(token),
+			Base:   client.Transport,
+		}
+		return client
+	}
+	defer func() {
+		newGitHubAppHTTPClient = origNewGitHubAppHTTPClient
+	}()
 
 	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM}, logging.NewLogger())
 	if err != nil {
@@ -207,5 +227,23 @@ func TestResolveInstallationTokenError(t *testing.T) {
 	client := NewGithubClient("default-token", logging.NewLogger())
 	if _, err := client.ResolveInstallationToken(context.Background(), &code.GitHubSetting{InstallationId: 12345}, ""); err == nil {
 		t.Fatal("Expected error but got none")
+	}
+}
+
+func TestResolveInstallationTokenRejectsUntrustedBaseURL(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	_, err = client.ResolveInstallationToken(context.Background(), &code.GitHubSetting{
+		BaseUrl:        "https://attacker.example/",
+		InstallationId: 12345,
+	}, "")
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "base_url host is not allowed") {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -1,0 +1,211 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/datasource-api/proto/code"
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+func generateRSAPrivateKeyPEM(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa private key: %v", err)
+	}
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	return privateKey, string(pem.EncodeToMemory(block))
+}
+
+func TestNewGithubClientWithAppAuth(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	cases := []struct {
+		name      string
+		conf      *AppAuthConfig
+		wantApp   bool
+		wantError bool
+	}{
+		{
+			name: "OK no app auth",
+		},
+		{
+			name: "OK empty app auth",
+			conf: &AppAuthConfig{},
+		},
+		{
+			name:    "OK app auth",
+			conf:    &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM},
+			wantApp: true,
+		},
+		{
+			name:      "NG missing private key",
+			conf:      &AppAuthConfig{AppID: "12345"},
+			wantError: true,
+		},
+		{
+			name:      "NG invalid app id",
+			conf:      &AppAuthConfig{AppID: "invalid", PrivateKey: privateKeyPEM},
+			wantError: true,
+		},
+		{
+			name:      "NG invalid private key",
+			conf:      &AppAuthConfig{AppID: "12345", PrivateKey: "invalid"},
+			wantError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client, err := NewGithubClientWithAppAuth("default-token", c.conf, logging.NewLogger())
+			if c.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got := client.SupportsGitHubApp(); got != c.wantApp {
+				t.Fatalf("Unexpected GitHub App support: want=%t, got=%t", c.wantApp, got)
+			}
+		})
+	}
+}
+
+func TestParseGitHubAppPrivateKey(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	escapedPEM := strings.ReplaceAll(privateKeyPEM, "\n", `\n`)
+	cases := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{name: "OK raw pem", input: privateKeyPEM},
+		{name: "OK escaped pem", input: escapedPEM},
+		{name: "NG invalid pem", input: "invalid", wantError: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseGitHubAppPrivateKey(c.input)
+			if c.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("Expected private key but got nil")
+			}
+		})
+	}
+}
+
+func TestCreateGitHubAppJWT(t *testing.T) {
+	privateKey, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	now := time.Now().Truncate(time.Second)
+	tokenString, err := client.createGitHubAppJWT(now)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	claims := &jwt.RegisteredClaims{}
+	parsed, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		if token.Method != jwt.SigningMethodRS256 {
+			t.Fatalf("Unexpected signing method: %v", token.Method.Alg())
+		}
+		return &privateKey.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("Unexpected parse error: %v", err)
+	}
+	if !parsed.Valid {
+		t.Fatal("Expected valid token")
+	}
+	if claims.Issuer != "12345" {
+		t.Fatalf("Unexpected issuer: %s", claims.Issuer)
+	}
+	if claims.IssuedAt.Time.Unix() != now.Add(-githubAppJWTBackdate).Unix() {
+		t.Fatalf("Unexpected issued_at: %v", claims.IssuedAt.Time)
+	}
+	if claims.ExpiresAt.Time.Unix() != now.Add(githubAppJWTLifetime).Unix() {
+		t.Fatalf("Unexpected expires_at: %v", claims.ExpiresAt.Time)
+	}
+}
+
+func TestResolveInstallationToken(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	var gotAuthorization string
+	var gotRepositories []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/12345/access_tokens" {
+			t.Fatalf("Unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("Unexpected method: %s", r.Method)
+		}
+		gotAuthorization = r.Header.Get("Authorization")
+		var body struct {
+			Repositories []string `json:"repositories"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		gotRepositories = body.Repositories
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
+			t.Fatalf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	got, err := client.ResolveInstallationToken(context.Background(), &code.GitHubSetting{
+		BaseUrl:        server.URL + "/",
+		InstallationId: 12345,
+	}, "owner/repo")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got != "installation-token" {
+		t.Fatalf("Unexpected token: %s", got)
+	}
+	if !strings.HasPrefix(gotAuthorization, "Bearer ") {
+		t.Fatalf("Unexpected authorization header: %s", gotAuthorization)
+	}
+	if len(gotRepositories) != 1 || gotRepositories[0] != "repo" {
+		t.Fatalf("Unexpected repositories: %+v", gotRepositories)
+	}
+}
+
+func TestResolveInstallationTokenError(t *testing.T) {
+	client := NewGithubClient("default-token", logging.NewLogger())
+	if _, err := client.ResolveInstallationToken(context.Background(), &code.GitHubSetting{InstallationId: 12345}, ""); err == nil {
+		t.Fatal("Expected error but got none")
+	}
+}

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -186,8 +186,6 @@ func TestResolveInstallationToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse test server URL: %v", err)
 	}
-	githubAppAllowedBaseURLHosts[serverURL.Hostname()] = struct{}{}
-	defer delete(githubAppAllowedBaseURLHosts, serverURL.Hostname())
 	origNewGitHubAppHTTPClient := newGitHubAppHTTPClient
 	newGitHubAppHTTPClient = func(ctx context.Context, token *oauth2.Token) *http.Client {
 		client := server.Client()
@@ -201,7 +199,11 @@ func TestResolveInstallationToken(t *testing.T) {
 		newGitHubAppHTTPClient = origNewGitHubAppHTTPClient
 	}()
 
-	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{AppID: "12345", PrivateKey: privateKeyPEM}, logging.NewLogger())
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{
+		AppID:               "12345",
+		PrivateKey:          privateKeyPEM,
+		AllowedBaseURLHosts: []string{serverURL.Hostname()},
+	}, logging.NewLogger())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -244,6 +246,21 @@ func TestResolveInstallationTokenRejectsUntrustedBaseURL(t *testing.T) {
 		t.Fatal("Expected error but got none")
 	}
 	if !strings.Contains(err.Error(), "base_url host is not allowed") {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestResolveInstallationTokenAllowsConfiguredBaseURLHost(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{
+		AppID:               "12345",
+		PrivateKey:          privateKeyPEM,
+		AllowedBaseURLHosts: []string{"ghe.example.com"},
+	}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if _, err := client.appAuth.validateBaseURL("https://ghe.example.com/api/v3/"); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -264,3 +264,64 @@ func TestResolveInstallationTokenAllowsConfiguredBaseURLHost(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
+
+func TestValidateGitHubAppBaseURLAddsTrailingSlash(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{
+		AppID:               "12345",
+		PrivateKey:          privateKeyPEM,
+		AllowedBaseURLHosts: []string{"ghe.example.com"},
+	}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	got, err := client.appAuth.validateBaseURL("https://ghe.example.com/api/v3")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if got.String() != "https://ghe.example.com/api/v3/" {
+		t.Fatalf("Unexpected base URL: %s", got.String())
+	}
+}
+
+func TestInstallationTokenOptions(t *testing.T) {
+	cases := []struct {
+		name      string
+		repoName  string
+		wantRepo  string
+		wantNil   bool
+		wantError bool
+	}{
+		{name: "OK empty", wantNil: true},
+		{name: "OK repo", repoName: "repo", wantRepo: "repo"},
+		{name: "OK owner repo", repoName: "owner/repo", wantRepo: "repo"},
+		{name: "OK trims spaces", repoName: " owner/repo ", wantRepo: "repo"},
+		{name: "NG too many segments", repoName: "a/b/c", wantError: true},
+		{name: "NG empty owner", repoName: "/repo", wantError: true},
+		{name: "NG empty repo", repoName: "owner/", wantError: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := installationTokenOptions(c.repoName)
+			if c.wantError {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if c.wantNil {
+				if got != nil {
+					t.Fatalf("Expected nil options but got %+v", got)
+				}
+				return
+			}
+			if got == nil || len(got.Repositories) != 1 || got.Repositories[0] != c.wantRepo {
+				t.Fatalf("Unexpected options: %+v", got)
+			}
+		})
+	}
+}

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -147,11 +147,11 @@ func TestCreateGitHubAppJWT(t *testing.T) {
 	if claims.Issuer != "12345" {
 		t.Fatalf("Unexpected issuer: %s", claims.Issuer)
 	}
-	if claims.IssuedAt.Time.Unix() != now.Add(-githubAppJWTBackdate).Unix() {
-		t.Fatalf("Unexpected issued_at: %v", claims.IssuedAt.Time)
+	if claims.IssuedAt.Unix() != now.Add(-githubAppJWTBackdate).Unix() {
+		t.Fatalf("Unexpected issued_at: %v", claims.IssuedAt)
 	}
-	if claims.ExpiresAt.Time.Unix() != now.Add(githubAppJWTLifetime).Unix() {
-		t.Fatalf("Unexpected expires_at: %v", claims.ExpiresAt.Time)
+	if claims.ExpiresAt.Unix() != now.Add(githubAppJWTLifetime).Unix() {
+		t.Fatalf("Unexpected expires_at: %v", claims.ExpiresAt)
 	}
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -21,6 +21,8 @@ const RETRY_NUM uint64 = 3
 type GithubServiceClient interface {
 	ListRepository(ctx context.Context, config *code.GitHubSetting, repoName string) ([]*github.Repository, error)
 	Clone(ctx context.Context, token string, cloneURL string, dstDir string) error
+	SupportsGitHubApp() bool
+	ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error)
 }
 
 type GitHubRepoService interface {
@@ -36,6 +38,7 @@ type GitHubV3Client struct {
 
 type riskenGitHubClient struct {
 	defaultToken string
+	appAuth      *appAuth
 	retryer      backoff.BackOff
 	logger       logging.Logger
 }
@@ -46,6 +49,16 @@ func NewGithubClient(defaultToken string, logger logging.Logger) *riskenGitHubCl
 		retryer:      backoff.WithMaxRetries(backoff.NewExponentialBackOff(), RETRY_NUM),
 		logger:       logger,
 	}
+}
+
+func NewGithubClientWithAppAuth(defaultToken string, appAuthConf *AppAuthConfig, logger logging.Logger) (*riskenGitHubClient, error) {
+	appAuth, err := newAppAuth(appAuthConf)
+	if err != nil {
+		return nil, err
+	}
+	client := NewGithubClient(defaultToken, logger)
+	client.appAuth = appAuth
+	return client, nil
 }
 
 func (g *riskenGitHubClient) newV3Client(ctx context.Context, token, baseURL string) (*GitHubV3Client, error) {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -31,8 +32,16 @@ type GitHubRepoService interface {
 	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
 }
 
+type GitHubAppService interface {
+	FindOrganizationInstallation(ctx context.Context, org string) (*github.Installation, *github.Response, error)
+	FindUserInstallation(ctx context.Context, user string) (*github.Installation, *github.Response, error)
+	CreateInstallationToken(ctx context.Context, id int64, opts *github.InstallationTokenOptions) (*github.InstallationToken, *github.Response, error)
+	ListRepos(ctx context.Context, opts *github.ListOptions) (*github.ListRepositories, *github.Response, error)
+}
+
 type GitHubV3Client struct {
 	Repositories GitHubRepoService
+	Apps         GitHubAppService
 	*github.Client
 }
 
@@ -44,21 +53,21 @@ type riskenGitHubClient struct {
 }
 
 func NewGithubClient(defaultToken string, logger logging.Logger) *riskenGitHubClient {
-	return &riskenGitHubClient{
-		defaultToken: defaultToken,
-		retryer:      backoff.WithMaxRetries(backoff.NewExponentialBackOff(), RETRY_NUM),
-		logger:       logger,
-	}
+	client, _ := NewGithubClientWithAppAuth(defaultToken, nil, logger)
+	return client
 }
 
-func NewGithubClientWithAppAuth(defaultToken string, appAuthConf *AppAuthConfig, logger logging.Logger) (*riskenGitHubClient, error) {
-	appAuth, err := newAppAuth(appAuthConf)
+func NewGithubClientWithAppAuth(defaultToken string, appAuthCfg *AppAuthConfig, logger logging.Logger) (*riskenGitHubClient, error) {
+	appAuth, err := newAppAuth(appAuthCfg)
 	if err != nil {
 		return nil, err
 	}
-	client := NewGithubClient(defaultToken, logger)
-	client.appAuth = appAuth
-	return client, nil
+	return &riskenGitHubClient{
+		defaultToken: defaultToken,
+		appAuth:      appAuth,
+		retryer:      backoff.WithMaxRetries(backoff.NewExponentialBackOff(), RETRY_NUM),
+		logger:       logger,
+	}, nil
 }
 
 func (g *riskenGitHubClient) newV3Client(ctx context.Context, token, baseURL string) (*GitHubV3Client, error) {
@@ -75,6 +84,7 @@ func (g *riskenGitHubClient) newV3Client(ctx context.Context, token, baseURL str
 	}
 	return &GitHubV3Client{
 		Repositories: client.Repositories,
+		Apps:         client.Apps,
 		Client:       client,
 	}, nil
 }
@@ -106,7 +116,11 @@ func (g *riskenGitHubClient) Clone(ctx context.Context, token string, cloneURL s
 }
 
 func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.GitHubSetting, repoName string) ([]*github.Repository, error) {
-	client, err := g.newV3Client(ctx, config.PersonalAccessToken, config.BaseUrl)
+	token, err := g.resolveAccessToken(ctx, config, repoName)
+	if err != nil {
+		return nil, err
+	}
+	client, err := g.newV3Client(ctx, token, config.BaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("create github-v3 client: %w", err)
 	}
@@ -118,6 +132,10 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 			return nil, err
 		}
 		return []*github.Repository{repository}, nil
+	}
+
+	if config.PersonalAccessToken == "" && g.appAuth != nil {
+		return g.listRepositoryForInstallation(ctx, client.Apps, config.TargetResource)
 	}
 
 	// Handle bulk repository scan based on config.Type
@@ -147,6 +165,61 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 	}
 
 	return repos, nil
+}
+
+func (g *riskenGitHubClient) resolveAccessToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {
+	if config.PersonalAccessToken != "" {
+		return config.PersonalAccessToken, nil
+	}
+	if g.appAuth != nil {
+		return g.ResolveInstallationToken(ctx, config, repoName)
+	}
+	return g.defaultToken, nil
+}
+
+func (g *riskenGitHubClient) listRepositoryForInstallation(ctx context.Context, appSvc GitHubAppService, targetResource string) ([]*github.Repository, error) {
+	var allRepo []*github.Repository
+	opt := &github.ListOptions{PerPage: 100}
+	for {
+		repositories, resp, err := appSvc.ListRepos(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			return nil, errors.New("github app list repositories response is nil")
+		}
+		repos := []*github.Repository{}
+		if repositories != nil {
+			repos = repositories.Repositories
+		} else {
+			g.logger.Warnf(ctx, "github app list repositories returned nil repositories: target_resource=%s, option=%+v, response=%+v", targetResource, opt, resp)
+		}
+		if targetResource != "" {
+			repos = filterRepositoriesByOwner(repos, targetResource)
+		}
+		allRepo = append(allRepo, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+	return allRepo, nil
+}
+
+func filterRepositoriesByOwner(repos []*github.Repository, owner string) []*github.Repository {
+	if owner == "" {
+		return repos
+	}
+	filtered := make([]*github.Repository, 0, len(repos))
+	for _, repo := range repos {
+		if repo == nil || repo.Owner == nil || repo.Owner.Login == nil {
+			continue
+		}
+		if strings.EqualFold(repo.GetOwner().GetLogin(), owner) {
+			filtered = append(filtered, repo)
+		}
+	}
+	return filtered
 }
 
 const (
@@ -235,12 +308,10 @@ func (g *riskenGitHubClient) GetSingleRepository(ctx context.Context, client *Gi
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid repository name format: %s, expected 'owner/repo'", repoName)
 	}
-	owner, repo := parts[0], parts[1]
-
-	// Validate that the repository belongs to the target resource
-	if owner != config.TargetResource {
-		return nil, fmt.Errorf("repository %s does not belong to %s %s", repoName, config.Type.String(), config.TargetResource)
+	if err := validateRepositoryBelongsToTarget(config, repoName); err != nil {
+		return nil, err
 	}
+	owner, repo := parts[0], parts[1]
 
 	repository, _, err := client.Repositories.Get(ctx, owner, repo)
 	if err != nil {
@@ -248,6 +319,18 @@ func (g *riskenGitHubClient) GetSingleRepository(ctx context.Context, client *Gi
 	}
 
 	return repository, nil
+}
+
+func validateRepositoryBelongsToTarget(config *code.GitHubSetting, repoName string) error {
+	parts := strings.Split(repoName, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid repository name format: %s, expected 'owner/repo'", repoName)
+	}
+	owner := parts[0]
+	if !strings.EqualFold(owner, config.TargetResource) {
+		return fmt.Errorf("repository %s does not belong to %s %s", repoName, config.Type.String(), config.TargetResource)
+	}
+	return nil
 }
 
 func (t *riskenGitHubClient) newRetryLogger(ctx context.Context, funcName string) func(error, time.Duration) {

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -2006,6 +2006,14 @@ func (g *FakeGithubClient) Clone(ctx context.Context, token string, cloneURL str
 	return g.err
 }
 
+func (g *FakeGithubClient) SupportsGitHubApp() bool {
+	return false
+}
+
+func (g *FakeGithubClient) ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {
+	return "", g.err
+}
+
 func TestBuildCodeQueueMessage(t *testing.T) {
 	repo := &ghub.Repository{
 		ID:            ghub.Int64(12345),

--- a/pkg/server/code/service.go
+++ b/pkg/server/code/service.go
@@ -32,14 +32,17 @@ type CodeQueue interface {
 	Send(ctx context.Context, url string, msg interface{}) (*sqs.SendMessageOutput, error)
 }
 
-func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, limitRepositorySizeKb int, l logging.Logger) (code.CodeServiceServer, error) {
+func NewCodeService(dataKey string, appAuth *github.AppAuthConfig, repo db.CodeRepoInterface, q *queue.Client, pj project.ProjectServiceClient, limitRepositorySizeKb int, l logging.Logger) (code.CodeServiceServer, error) {
 	key := []byte(dataKey)
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher, err=%w", err)
 	}
 
-	githubClient := github.NewGithubClient("", l)
+	githubClient, err := github.NewGithubClientWithAppAuth("", appAuth, l)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create github client, err=%w", err)
+	}
 
 	return &CodeService{
 		repository:             repo,
@@ -51,6 +54,6 @@ func NewCodeService(dataKey string, repo db.CodeRepoInterface, q *queue.Client, 
 		codeDependencyQueueURL: q.CodeDependencyQueueURL,
 		codeCodeScanQueueURL:   q.CodeCodeScanQueueURL,
 		githubClient:           githubClient,
-		limitRepositorySizeKb: limitRepositorySizeKb,
+		limitRepositorySizeKb:  limitRepositorySizeKb,
 	}, nil
 }

--- a/pkg/server/code/service_test.go
+++ b/pkg/server/code/service_test.go
@@ -1,0 +1,56 @@
+package code
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/datasource-api/pkg/github"
+	"github.com/ca-risken/datasource-api/pkg/queue"
+)
+
+func TestNewCodeService(t *testing.T) {
+	cases := []struct {
+		name      string
+		dataKey   string
+		appAuth   *github.AppAuthConfig
+		wantError string
+	}{
+		{
+			name:    "OK without github app auth",
+			dataKey: "12345678901234567890123456789012",
+		},
+		{
+			name:      "NG invalid data key",
+			dataKey:   "short",
+			wantError: "failed to create cipher",
+		},
+		{
+			name:      "NG invalid github app auth",
+			dataKey:   "12345678901234567890123456789012",
+			appAuth:   &github.AppAuthConfig{AppID: "12345"},
+			wantError: "failed to create github client",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := NewCodeService(c.dataKey, c.appAuth, nil, &queue.Client{}, nil, 0, logging.NewLogger())
+			if c.wantError != "" {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), c.wantError) {
+					t.Fatalf("Expected error to contain %q, got %v", c.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("Expected service but got nil")
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	azureClient "github.com/ca-risken/datasource-api/pkg/azure"
 	"github.com/ca-risken/datasource-api/pkg/db"
 	"github.com/ca-risken/datasource-api/pkg/gcp"
+	"github.com/ca-risken/datasource-api/pkg/github"
 	"github.com/ca-risken/datasource-api/pkg/queue"
 	awsServer "github.com/ca-risken/datasource-api/pkg/server/aws"
 	azureServer "github.com/ca-risken/datasource-api/pkg/server/azure"
@@ -42,34 +43,36 @@ import (
 )
 
 type Server struct {
-	port                 string
-	coreSvcAddr          string
-	awsRegion            string
-	googleCredentialPath string
-	dataKey              string
-	db                   *db.Client
-	queue                *queue.Client
-	baseURL              string
-	defaultLocale        string
-	slackAPIToken        string
+	port                  string
+	coreSvcAddr           string
+	awsRegion             string
+	googleCredentialPath  string
+	dataKey               string
+	githubAppAuth         *github.AppAuthConfig
+	db                    *db.Client
+	queue                 *queue.Client
+	baseURL               string
+	defaultLocale         string
+	slackAPIToken         string
 	limitRepositorySizeKb int
-	logger               logging.Logger
+	logger                logging.Logger
 }
 
-func NewServer(port, coreSvcAddr, awsRegion, googleCredentialPath, dataKey string, db *db.Client, q *queue.Client, url, defaultLocale, slackAPIToken string, limitRepositorySizeKb int, logger logging.Logger) *Server {
+func NewServer(port, coreSvcAddr, awsRegion, googleCredentialPath, dataKey string, githubAppAuth *github.AppAuthConfig, db *db.Client, q *queue.Client, url, defaultLocale, slackAPIToken string, limitRepositorySizeKb int, logger logging.Logger) *Server {
 	return &Server{
-		port:                 port,
-		coreSvcAddr:          coreSvcAddr,
-		awsRegion:            awsRegion,
-		googleCredentialPath: googleCredentialPath,
-		dataKey:              dataKey,
-		db:                   db,
-		queue:                q,
-		baseURL:              url,
-		defaultLocale:        defaultLocale,
-		slackAPIToken:        slackAPIToken,
+		port:                  port,
+		coreSvcAddr:           coreSvcAddr,
+		awsRegion:             awsRegion,
+		googleCredentialPath:  googleCredentialPath,
+		dataKey:               dataKey,
+		githubAppAuth:         githubAppAuth,
+		db:                    db,
+		queue:                 q,
+		baseURL:               url,
+		defaultLocale:         defaultLocale,
+		slackAPIToken:         slackAPIToken,
 		limitRepositorySizeKb: limitRepositorySizeKb,
-		logger:               logger,
+		logger:                logger,
 	}
 }
 
@@ -99,7 +102,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	awsSvc := awsServer.NewAWSService(s.db, s.queue, pjClient, s.logger)
 	googleSvc := googleServer.NewGoogleService(ctx, gcpClient, s.db, s.queue, pjClient, s.logger)
-	codeSvc, err := codeServer.NewCodeService(s.dataKey, s.db, s.queue, pjClient, s.limitRepositorySizeKb, s.logger)
+	codeSvc, err := codeServer.NewCodeService(s.dataKey, s.githubAppAuth, s.db, s.queue, pjClient, s.limitRepositorySizeKb, s.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create code service: %w", err)
 	}


### PR DESCRIPTION
GitHub App認証で使う GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY を datasource-api に読み込ませ、GitHub App JWTを生成して Installation Token を発行できる基盤を追加します。
既存のPAT認証は残していて、GitHub App設定が未指定なら従来どおり動きます。

追加・変更した主な内容:

- datasource-api に GitHub App認証設定を追加
- GitHub App JWT生成と Installation Token 取得処理を追加
- private key の通常PEM / \n エスケープ形式に対応