### PR TITLE
[add]resolve-ghapp-installation-token

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -136,6 +136,9 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 	}
 
 	if config.AuthMode == code.GitHubAuthModeGitHubApp {
+		if g.appAuth == nil {
+			return nil, errors.New("github app auth is not configured")
+		}
 		return g.listRepositoryForInstallation(ctx, client.Apps, config.TargetResource)
 	}
 
@@ -170,6 +173,9 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 
 func (g *riskenGitHubClient) resolveAccessToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {
 	if config.AuthMode == code.GitHubAuthModeGitHubApp {
+		if g.appAuth == nil {
+			return "", errors.New("github app auth is not configured")
+		}
 		return g.ResolveInstallationToken(ctx, config, repoName)
 	}
 	if config.PersonalAccessToken != "" {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -136,9 +136,6 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 	}
 
 	if config.AuthMode == code.GitHubAuthModeGitHubApp {
-		if g.appAuth == nil {
-			return nil, errors.New("github app auth is not configured")
-		}
 		return g.listRepositoryForInstallation(ctx, client.Apps, config.TargetResource)
 	}
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -135,7 +135,7 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 		return []*github.Repository{repository}, nil
 	}
 
-	if config.PersonalAccessToken == "" && g.appAuth != nil {
+	if config.AuthMode == code.GitHubAuthModeGitHubApp {
 		return g.listRepositoryForInstallation(ctx, client.Apps, config.TargetResource)
 	}
 
@@ -169,11 +169,11 @@ func (g *riskenGitHubClient) ListRepository(ctx context.Context, config *code.Gi
 }
 
 func (g *riskenGitHubClient) resolveAccessToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {
+	if config.AuthMode == code.GitHubAuthModeGitHubApp {
+		return g.ResolveInstallationToken(ctx, config, repoName)
+	}
 	if config.PersonalAccessToken != "" {
 		return config.PersonalAccessToken, nil
-	}
-	if g.appAuth != nil {
-		return g.ResolveInstallationToken(ctx, config, repoName)
 	}
 	return g.defaultToken, nil
 }

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -171,6 +171,50 @@ func Test_listRepositoryForOrgWithOption(t *testing.T) {
 	}
 }
 
+func TestResolveAccessTokenAuthMode(t *testing.T) {
+	client := NewGithubClient("default-token", logging.NewLogger())
+	cases := []struct {
+		name    string
+		config  *code.GitHubSetting
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "PAT mode uses personal access token",
+			config: &code.GitHubSetting{AuthMode: code.GitHubAuthModePersonalAccessToken, PersonalAccessToken: "pat-token"},
+			want:   "pat-token",
+		},
+		{
+			name:   "empty auth mode falls back to default token",
+			config: &code.GitHubSetting{},
+			want:   "default-token",
+		},
+		{
+			name:    "GitHub App mode does not fall back to PAT or default token",
+			config:  &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp, PersonalAccessToken: "pat-token", InstallationId: 12345},
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := client.resolveAccessToken(context.Background(), c.config, "")
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error occurred: %+v", err)
+			}
+			if got != c.want {
+				t.Fatalf("Unexpected token: want=%s, got=%s", c.want, got)
+			}
+		})
+	}
+}
+
 func TestGetSingleRepository(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -174,10 +174,11 @@ func Test_listRepositoryForOrgWithOption(t *testing.T) {
 func TestResolveAccessTokenAuthMode(t *testing.T) {
 	client := NewGithubClient("default-token", logging.NewLogger())
 	cases := []struct {
-		name    string
-		config  *code.GitHubSetting
-		want    string
-		wantErr bool
+		name        string
+		config      *code.GitHubSetting
+		want        string
+		wantErr     bool
+		wantErrText string
 	}{
 		{
 			name:   "PAT mode uses personal access token",
@@ -190,9 +191,10 @@ func TestResolveAccessTokenAuthMode(t *testing.T) {
 			want:   "default-token",
 		},
 		{
-			name:    "GitHub App mode does not fall back to PAT or default token",
-			config:  &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp, PersonalAccessToken: "pat-token", InstallationId: 12345},
-			wantErr: true,
+			name:        "GitHub App mode requires configured app auth",
+			config:      &code.GitHubSetting{AuthMode: code.GitHubAuthModeGitHubApp, PersonalAccessToken: "pat-token", InstallationId: 12345},
+			wantErr:     true,
+			wantErrText: "github app auth is not configured",
 		},
 	}
 
@@ -203,6 +205,9 @@ func TestResolveAccessTokenAuthMode(t *testing.T) {
 				if err == nil {
 					t.Fatal("Expected error but got none")
 				}
+				if c.wantErrText != "" && !strings.Contains(err.Error(), c.wantErrText) {
+					t.Fatalf("Unexpected error: want contains=%q, got=%q", c.wantErrText, err.Error())
+				}
 				return
 			}
 			if err != nil {
@@ -212,6 +217,22 @@ func TestResolveAccessTokenAuthMode(t *testing.T) {
 				t.Fatalf("Unexpected token: want=%s, got=%s", c.want, got)
 			}
 		})
+	}
+}
+
+func TestListRepositoryGitHubAppWithoutAppAuth(t *testing.T) {
+	client := NewGithubClient("default-token", logging.NewLogger())
+	_, err := client.ListRepository(context.Background(), &code.GitHubSetting{
+		AuthMode:       code.GitHubAuthModeGitHubApp,
+		Type:           code.Type_ORGANIZATION,
+		TargetResource: "ca-risken",
+		InstallationId: 12345,
+	}, "")
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "github app auth is not configured") {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }
 

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -966,6 +966,36 @@ func (c *CodeService) PutDependencyRepository(ctx context.Context, req *code.Put
 	return &empty.Empty{}, nil
 }
 
+func (c *CodeService) buildGitHubSettingForRepositoryList(ctx context.Context, gitHubSetting *model.CodeGitHubSetting, projectID, githubSettingID uint32) (*code.GitHubSetting, error) {
+	protoGitHubSetting := convertGitHubSetting(gitHubSetting, nil, nil, nil, false)
+	if gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+		if gitHubSetting.VerificationStatus != code.GitHubVerificationStatusSuccess {
+			return nil, fmt.Errorf("github app installation is not verified: project_id=%d, github_setting_id=%d", projectID, githubSettingID)
+		}
+		if !c.githubClient.SupportsGitHubApp() {
+			return nil, fmt.Errorf("github app auth is not configured")
+		}
+		protoGitHubSetting.PersonalAccessToken = ""
+		return protoGitHubSetting, nil
+	}
+
+	if gitHubSetting.PersonalAccessToken == "" {
+		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)
+		return protoGitHubSetting, nil
+	}
+	decryptedPAT, err := decryptWithBase64(&c.cipherBlock, gitHubSetting.PersonalAccessToken)
+	if err != nil {
+		c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v", err)
+		return nil, fmt.Errorf("failed to decrypt PAT: %w", err)
+	}
+	if decryptedPAT == "" {
+		c.logger.Errorf(ctx, "Failed to decrypt PAT: decrypted PAT is empty, project_id=%d, github_setting_id=%d", projectID, githubSettingID)
+		return nil, fmt.Errorf("decrypted PAT is empty")
+	}
+	protoGitHubSetting.PersonalAccessToken = decryptedPAT
+	return protoGitHubSetting, nil
+}
+
 // listGitleaksTargetRepository lists repositories filtered by GitleaksSetting (internal function)
 func (c *CodeService) listGitleaksTargetRepository(ctx context.Context, projectID, githubSettingID uint32) ([]*ghub.Repository, error) {
 	// Get GitHub setting to use for API call
@@ -987,27 +1017,10 @@ func (c *CodeService) listGitleaksTargetRepository(ctx context.Context, projectI
 		return nil, err
 	}
 
-	// Decrypt PAT before using it for GitHub API call
-	decryptedPAT := ""
-	if githubSetting.PersonalAccessToken != "" {
-		decrypted, err := decryptWithBase64(&c.cipherBlock, githubSetting.PersonalAccessToken)
-		if err != nil {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v", err)
-			return nil, fmt.Errorf("failed to decrypt PAT: %w", err)
-		}
-		decryptedPAT = decrypted
-		if decryptedPAT == "" {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: decrypted PAT is empty, project_id=%d, github_setting_id=%d", projectID, githubSettingID)
-			return nil, fmt.Errorf("decrypted PAT is empty")
-		}
-	} else {
-		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)
+	protoGitHubSetting, err := c.buildGitHubSettingForRepositoryList(ctx, githubSetting, projectID, githubSettingID)
+	if err != nil {
+		return nil, err
 	}
-
-	// Convert model to proto for GitHub API call
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	// Override with decrypted PAT
-	protoGitHubSetting.PersonalAccessToken = decryptedPAT
 
 	// Call GitHub API to list repositories
 	repos, err := c.githubClient.ListRepository(ctx, protoGitHubSetting, "")
@@ -1053,27 +1066,10 @@ func (c *CodeService) listDependencyTargetRepository(ctx context.Context, projec
 		return nil, err
 	}
 
-	// Decrypt PAT before using it for GitHub API call
-	decryptedPAT := ""
-	if githubSetting.PersonalAccessToken != "" {
-		decrypted, err := decryptWithBase64(&c.cipherBlock, githubSetting.PersonalAccessToken)
-		if err != nil {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v", err)
-			return nil, fmt.Errorf("failed to decrypt PAT: %w", err)
-		}
-		decryptedPAT = decrypted
-		if decryptedPAT == "" {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: decrypted PAT is empty, project_id=%d, github_setting_id=%d", projectID, githubSettingID)
-			return nil, fmt.Errorf("decrypted PAT is empty")
-		}
-	} else {
-		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)
+	protoGitHubSetting, err := c.buildGitHubSettingForRepositoryList(ctx, githubSetting, projectID, githubSettingID)
+	if err != nil {
+		return nil, err
 	}
-
-	// Convert model to proto for GitHub API call
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	// Override with decrypted PAT
-	protoGitHubSetting.PersonalAccessToken = decryptedPAT
 
 	// Call GitHub API to list repositories
 	repos, err := c.githubClient.ListRepository(ctx, protoGitHubSetting, "")
@@ -1126,27 +1122,10 @@ func (c *CodeService) listCodescanTargetRepository(ctx context.Context, projectI
 		return nil, err
 	}
 
-	// Decrypt PAT before using it for GitHub API call
-	decryptedPAT := ""
-	if githubSetting.PersonalAccessToken != "" {
-		decrypted, err := decryptWithBase64(&c.cipherBlock, githubSetting.PersonalAccessToken)
-		if err != nil {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: err=%+v", err)
-			return nil, fmt.Errorf("failed to decrypt PAT: %w", err)
-		}
-		decryptedPAT = decrypted
-		if decryptedPAT == "" {
-			c.logger.Errorf(ctx, "Failed to decrypt PAT: decrypted PAT is empty, project_id=%d, github_setting_id=%d", projectID, githubSettingID)
-			return nil, fmt.Errorf("decrypted PAT is empty")
-		}
-	} else {
-		c.logger.Warnf(ctx, "PersonalAccessToken is empty for github_setting_id=%d", githubSettingID)
+	protoGitHubSetting, err := c.buildGitHubSettingForRepositoryList(ctx, githubSetting, projectID, githubSettingID)
+	if err != nil {
+		return nil, err
 	}
-
-	// Convert model to proto for GitHub API call
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	// Override with decrypted PAT
-	protoGitHubSetting.PersonalAccessToken = decryptedPAT
 
 	// Call GitHub API to list repositories
 	repos, err := c.githubClient.ListRepository(ctx, protoGitHubSetting, "")

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -1503,6 +1503,128 @@ func TestInvokeScan(t *testing.T) {
 	}
 }
 
+func TestBuildGitHubSettingForRepositoryList(t *testing.T) {
+	now := time.Now()
+	installationID := uint64(12345)
+	block, err := aes.NewCipher([]byte("1234567890123456"))
+	if err != nil {
+		t.Fatalf("failed to create cipher: %+v", err)
+	}
+	encryptedPAT, err := encryptWithBase64(&block, "plain-token")
+	if err != nil {
+		t.Fatalf("failed to encrypt token: %+v", err)
+	}
+
+	cases := []struct {
+		name              string
+		input             *model.CodeGitHubSetting
+		supportsGitHubApp bool
+		wantPAT           string
+		wantErr           bool
+	}{
+		{
+			name: "OK PAT decrypts token",
+			input: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				Type:                "ORGANIZATION",
+				TargetResource:      "ca-risken",
+				PersonalAccessToken: encryptedPAT,
+				AuthMode:            code.GitHubAuthModePersonalAccessToken,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+			wantPAT: "plain-token",
+		},
+		{
+			name: "OK GitHub App clears PAT and keeps installation id",
+			input: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				Type:                "ORGANIZATION",
+				TargetResource:      "ca-risken",
+				PersonalAccessToken: "stale-pat",
+				InstallationID:      &installationID,
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				VerificationStatus:  code.GitHubVerificationStatusSuccess,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+			supportsGitHubApp: true,
+			wantPAT:           "",
+		},
+		{
+			name: "NG GitHub App unverified",
+			input: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				Type:                "ORGANIZATION",
+				TargetResource:      "ca-risken",
+				InstallationID:      &installationID,
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				VerificationStatus:  code.GitHubVerificationStatusFailed,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+			supportsGitHubApp: true,
+			wantErr:           true,
+		},
+		{
+			name: "NG GitHub App auth is not configured",
+			input: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				Type:                "ORGANIZATION",
+				TargetResource:      "ca-risken",
+				InstallationID:      &installationID,
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				VerificationStatus:  code.GitHubVerificationStatusSuccess,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "OK empty PAT keeps existing default-token path",
+			input: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				Type:                "ORGANIZATION",
+				TargetResource:      "ca-risken",
+				AuthMode:            code.GitHubAuthModePersonalAccessToken,
+				CreatedAt:           now,
+				UpdatedAt:           now,
+			},
+			wantPAT: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client := newFakeGithubClient(nil, nil)
+			client.supportsGitHubApp = c.supportsGitHubApp
+			svc := CodeService{logger: logging.NewLogger(), githubClient: client, cipherBlock: block}
+
+			got, err := svc.buildGitHubSettingForRepositoryList(context.Background(), c.input, c.input.ProjectID, c.input.CodeGitHubSettingID)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("Unexpected no error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error occured: %+v", err)
+			}
+			if got.PersonalAccessToken != c.wantPAT {
+				t.Fatalf("unexpected personal access token: want=%q, got=%q", c.wantPAT, got.PersonalAccessToken)
+			}
+			if c.input.AuthMode == code.GitHubAuthModeGitHubApp && got.InstallationId != installationID {
+				t.Fatalf("unexpected installation id: want=%d, got=%d", installationID, got.InstallationId)
+			}
+		})
+	}
+}
+
 func TestInvokeScanDependency(t *testing.T) {
 	now := time.Now()
 	cases := []struct {
@@ -2081,8 +2203,11 @@ func (c *FakeCodeQueue) Send(ctx context.Context, url string, msg interface{}) (
 }
 
 type FakeGithubClient struct {
-	repos []*ghub.Repository
-	err   error
+	repos             []*ghub.Repository
+	err               error
+	supportsGitHubApp bool
+	gotConfig         *code.GitHubSetting
+	gotRepoName       string
 }
 
 func newFakeGithubClient(repos []*ghub.Repository, err error) *FakeGithubClient {
@@ -2093,6 +2218,8 @@ func newFakeGithubClient(repos []*ghub.Repository, err error) *FakeGithubClient 
 }
 
 func (g *FakeGithubClient) ListRepository(ctx context.Context, config *code.GitHubSetting, repoName string) ([]*ghub.Repository, error) {
+	g.gotConfig = config
+	g.gotRepoName = repoName
 	return g.repos, g.err
 }
 
@@ -2101,7 +2228,7 @@ func (g *FakeGithubClient) Clone(ctx context.Context, token string, cloneURL str
 }
 
 func (g *FakeGithubClient) SupportsGitHubApp() bool {
-	return false
+	return g.supportsGitHubApp
 }
 
 func (g *FakeGithubClient) ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error) {


### PR DESCRIPTION
- PAT / 未指定: 既存通り、PATがあれば復号してGitHub APIに渡す。PAT空なら従来のdefault token経路を維持。
- GITHUB_APP: verification_status=SUCCESSかつGitHub App auth設定済みの場合だけ許可。PATは使わず、installation token経路でRepository一覧を取得。
- GitHub client側も、GitHub App tokenを使う条件を「PATが空」ではなく「auth_mode=GITHUB_APP」に変更。