### PR TITLE
GitHub App設定のinstallation_id自動解決に対応

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -21,6 +21,7 @@ type CodeRepoInterface interface {
 	GetGitHubSetting(ctx context.Context, projectID, GitHubSettingID uint32) (*model.CodeGitHubSetting, error)
 	UpsertGitHubSetting(ctx context.Context, data *code.GitHubSettingForUpsert) (*model.CodeGitHubSetting, error)
 	UpdateGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
+	UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
 	DeleteGitHubSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
 	// code_gitleaks_setting
@@ -302,6 +303,18 @@ WHERE project_id = ?
 	AND auth_mode = ?
 `
 
+const updateGitHubAppInstallationVerification = `
+UPDATE code_github_setting
+SET
+	installation_id = ?,
+	verification_status = ?,
+	verified_github_user = CASE WHEN ? = ? THEN ? ELSE verified_github_user END,
+	verified_at = ?
+WHERE project_id = ?
+	AND code_github_setting_id = ?
+	AND auth_mode = ?
+`
+
 func (c *Client) UpdateGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {
 	result := c.MasterDB.WithContext(ctx).Exec(updateGitHubAppVerification,
 		verificationStatus,
@@ -317,6 +330,29 @@ func (c *Client) UpdateGitHubAppVerification(ctx context.Context, projectID, git
 	}
 	if result.RowsAffected == 0 {
 		return nil, fmt.Errorf("github app verification was not updated: project_id=%d, github_setting_id=%d", projectID, githubSettingID)
+	}
+	return c.GetGitHubSetting(ctx, projectID, githubSettingID)
+}
+
+func (c *Client) UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {
+	if installationID == 0 {
+		return nil, errors.New("installation_id is required")
+	}
+	result := c.MasterDB.WithContext(ctx).Exec(updateGitHubAppInstallationVerification,
+		installationID,
+		verificationStatus,
+		verificationStatus,
+		code.GitHubVerificationStatusSuccess,
+		convertZeroValueToNull(verifiedGitHubUser),
+		verifiedAt,
+		projectID,
+		githubSettingID,
+		code.GitHubAuthModeGitHubApp)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, fmt.Errorf("github app installation verification was not updated: project_id=%d, github_setting_id=%d", projectID, githubSettingID)
 	}
 	return c.GetGitHubSetting(ctx, projectID, githubSettingID)
 }

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -205,6 +205,21 @@ func TestUpsertGitHubSetting(t *testing.T) {
 			},
 		},
 		{
+			name: "OK github app without installation id",
+			args: args{
+				data: &code.GitHubSettingForUpsert{GithubSettingId: 1, Name: "name", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "user", AuthMode: code.GitHubAuthModeGitHubApp},
+			},
+			want:    &model.CodeGitHubSetting{CodeGitHubSettingID: 1, Name: "github_setting1", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "user", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now},
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				query := strings.Replace(upsertGitHubAppAuth, "?, ?, ?, ?, ?, ?, ?, ?, ?, ?", "?, ?, ?, ?, ?, ?, ?, ?, NULL, ?", 1)
+				mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta(selectGetCodeGitHubSettingByUniqueIndex)).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "name", "project_id", "type", "target_resource", "github_user", "auth_mode", "created_at", "updated_at"}).
+					AddRow(uint32(1), "github_setting1", uint32(1), "ORGANIZATION", "target", "user", code.GitHubAuthModeGitHubApp, now, now))
+			},
+		},
+		{
 			name: "OK personal access token auth mode",
 			args: args{
 				data: &code.GitHubSettingForUpsert{GithubSettingId: 1, Name: "name", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "user", AuthMode: code.GitHubAuthModePersonalAccessToken},
@@ -322,6 +337,86 @@ func TestUpdateGitHubAppVerification(t *testing.T) {
 			}
 			c.mockClosure(mock)
 			got, err := db.UpdateGitHubAppVerification(ctx, 1, 1, code.GitHubVerificationStatusSuccess, "octocat", now)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestUpdateGitHubAppInstallationVerification(t *testing.T) {
+	now := time.Now()
+	installationID := uint64(12345)
+	cases := []struct {
+		name        string
+		want        *model.CodeGitHubSetting
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK",
+			want: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1,
+				ProjectID:           1,
+				InstallationID:      &installationID,
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				VerificationStatus:  code.GitHubVerificationStatusSuccess,
+				VerifiedGitHubUser:  "octocat",
+				VerifiedAt:          now,
+			},
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
+					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+					"code_github_setting_id", "project_id", "installation_id", "auth_mode", "verification_status", "verified_github_user", "verified_at"}).
+					AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusSuccess, "octocat", now))
+			},
+		},
+		{
+			name:    "NG installation_id is zero",
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+			},
+		},
+		{
+			name:    "NG no rows updated",
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
+					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WillReturnResult(sqlmock.NewResult(1, 0))
+			},
+		},
+		{
+			name:    "NG DB error",
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
+					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			inputInstallationID := installationID
+			if c.name == "NG installation_id is zero" {
+				inputInstallationID = 0
+			}
+			got, err := db.UpdateGitHubAppInstallationVerification(ctx, 1, 1, inputInstallationID, code.GitHubVerificationStatusSuccess, "octocat", now)
 			if err != nil && !c.wantErr {
 				t.Fatalf("Unexpected error: %+v", err)
 			}

--- a/pkg/db/mocks/CodeRepoInterface.go
+++ b/pkg/db/mocks/CodeRepoInterface.go
@@ -938,6 +938,36 @@ func (_m *CodeRepoInterface) UpdateGitHubAppVerification(ctx context.Context, pr
 	return r0, r1
 }
 
+// UpdateGitHubAppInstallationVerification provides a mock function with given fields: ctx, projectID, githubSettingID, installationID, verificationStatus, verifiedGitHubUser, verifiedAt
+func (_m *CodeRepoInterface) UpdateGitHubAppInstallationVerification(ctx context.Context, projectID uint32, githubSettingID uint32, installationID uint64, verificationStatus string, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {
+	ret := _m.Called(ctx, projectID, githubSettingID, installationID, verificationStatus, verifiedGitHubUser, verifiedAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateGitHubAppInstallationVerification")
+	}
+
+	var r0 *model.CodeGitHubSetting
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, uint64, string, string, time.Time) (*model.CodeGitHubSetting, error)); ok {
+		return rf(ctx, projectID, githubSettingID, installationID, verificationStatus, verifiedGitHubUser, verifiedAt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, uint64, string, string, time.Time) *model.CodeGitHubSetting); ok {
+		r0 = rf(ctx, projectID, githubSettingID, installationID, verificationStatus, verifiedGitHubUser, verifiedAt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.CodeGitHubSetting)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32, uint64, string, string, time.Time) error); ok {
+		r1 = rf(ctx, projectID, githubSettingID, installationID, verificationStatus, verifiedGitHubUser, verifiedAt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpsertGitleaksCache provides a mock function with given fields: ctx, projectID, data
 func (_m *CodeRepoInterface) UpsertGitleaksCache(ctx context.Context, projectID uint32, data *code.GitleaksCacheForUpsert) (*model.CodeGitleaksCache, error) {
 	ret := _m.Called(ctx, projectID, data)

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -71,32 +71,31 @@ func (g *riskenGitHubClient) ResolveInstallationToken(ctx context.Context, confi
 	}, repoName)
 }
 
-func (g *riskenGitHubClient) VerifyInstallation(ctx context.Context, config *code.GitHubSetting) error {
+func (g *riskenGitHubClient) VerifyInstallation(ctx context.Context, config *code.GitHubSetting) (uint64, error) {
 	if g.appAuth == nil {
-		return errors.New("github app auth is not configured")
+		return 0, errors.New("github app auth is not configured")
 	}
 	if config == nil {
-		return errors.New("github setting is required")
-	}
-	if config.InstallationId == 0 {
-		return errors.New("installation_id is required")
+		return 0, errors.New("github setting is required")
 	}
 	client, err := g.newGitHubAppClient(ctx, config.BaseUrl)
 	if err != nil {
-		return fmt.Errorf("create github app client: %w", err)
+		return 0, fmt.Errorf("create github app client: %w", err)
 	}
 	installation, _, err := findInstallation(ctx, client.Apps, config)
 	if err != nil {
-		return fmt.Errorf("find installation: %w", err)
+		return 0, fmt.Errorf("find installation: %w", err)
 	}
-	if installation.GetID() != int64(config.InstallationId) {
-		g.logger.Warnf(ctx, "github app installation_id mismatch: expected=%d, actual=%d", config.InstallationId, installation.GetID())
-		return errors.New("installation_id does not match target resource")
+	resolvedInstallationID := installation.GetID()
+	if resolvedInstallationID <= 0 {
+		return 0, errors.New("installation_id is required")
 	}
-	if _, err := g.ResolveInstallationToken(ctx, config, ""); err != nil {
-		return fmt.Errorf("resolve installation token: %w", err)
+	resolvedConfig := *config
+	resolvedConfig.InstallationId = uint64(resolvedInstallationID)
+	if _, err := g.ResolveInstallationToken(ctx, &resolvedConfig, ""); err != nil {
+		return 0, fmt.Errorf("resolve installation token: %w", err)
 	}
-	return nil
+	return uint64(resolvedInstallationID), nil
 }
 
 func findInstallation(ctx context.Context, appSvc GitHubAppService, config *code.GitHubSetting) (*ghub.Installation, *ghub.Response, error) {

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -90,9 +90,10 @@ func (g *riskenGitHubClient) VerifyInstallation(ctx context.Context, config *cod
 	if resolvedInstallationID <= 0 {
 		return 0, errors.New("installation_id is required")
 	}
-	resolvedConfig := *config
-	resolvedConfig.InstallationId = uint64(resolvedInstallationID)
-	if _, err := g.ResolveInstallationToken(ctx, &resolvedConfig, ""); err != nil {
+	if _, err := g.appAuth.ResolveInstallationToken(ctx, &githubappauth.InstallationTokenConfig{
+		BaseURL:        config.BaseUrl,
+		InstallationID: uint64(resolvedInstallationID),
+	}, ""); err != nil {
 		return 0, fmt.Errorf("resolve installation token: %w", err)
 	}
 	return uint64(resolvedInstallationID), nil

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -214,7 +214,7 @@ func TestVerifyInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = client.VerifyInstallation(context.Background(), &code.GitHubSetting{
+	installationID, err := client.VerifyInstallation(context.Background(), &code.GitHubSetting{
 		Type:           code.Type_ORGANIZATION,
 		TargetResource: "target",
 		BaseUrl:        server.URL + "/",
@@ -226,16 +226,27 @@ func TestVerifyInstallation(t *testing.T) {
 	if !gotFindInstallation || !gotCreateToken {
 		t.Fatalf("Expected find installation and create token calls, gotFindInstallation=%t, gotCreateToken=%t", gotFindInstallation, gotCreateToken)
 	}
+	if installationID != 12345 {
+		t.Fatalf("Unexpected installation_id: want=12345, got=%d", installationID)
+	}
 }
 
-func TestVerifyInstallationReturnsAbstractMismatchError(t *testing.T) {
+func TestVerifyInstallationResolvesMissingInstallationID(t *testing.T) {
 	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	var gotFindInstallation bool
+	var gotCreateToken bool
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/target/installation":
-			if _, err := w.Write([]byte(`{"id":99999}`)); err != nil {
+			gotFindInstallation = true
+			if _, err := w.Write([]byte(`{"id":12345}`)); err != nil {
 				t.Fatalf("write installation response: %v", err)
+			}
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
+			gotCreateToken = true
+			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
+				t.Fatalf("write token response: %v", err)
 			}
 		default:
 			t.Fatalf("Unexpected request: method=%s path=%s", r.Method, r.URL.Path)
@@ -256,20 +267,70 @@ func TestVerifyInstallationReturnsAbstractMismatchError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	err = client.VerifyInstallation(context.Background(), &code.GitHubSetting{
+	installationID, err := client.VerifyInstallation(context.Background(), &code.GitHubSetting{
+		Type:           code.Type_ORGANIZATION,
+		TargetResource: "target",
+		BaseUrl:        server.URL + "/",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !gotFindInstallation || !gotCreateToken {
+		t.Fatalf("Expected find installation and create token calls, gotFindInstallation=%t, gotCreateToken=%t", gotFindInstallation, gotCreateToken)
+	}
+	if installationID != 12345 {
+		t.Fatalf("Unexpected installation_id: want=12345, got=%d", installationID)
+	}
+}
+
+func TestVerifyInstallationUsesResolvedInstallationID(t *testing.T) {
+	_, privateKeyPEM := generateRSAPrivateKeyPEM(t)
+	var gotCreateToken bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/orgs/target/installation":
+			if _, err := w.Write([]byte(`{"id":99999}`)); err != nil {
+				t.Fatalf("write installation response: %v", err)
+			}
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/99999/access_tokens":
+			gotCreateToken = true
+			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
+				t.Fatalf("write token response: %v", err)
+			}
+		default:
+			t.Fatalf("Unexpected request: method=%s path=%s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	useTestGitHubAppTransport(t, server)
+
+	client, err := NewGithubClientWithAppAuth("default-token", &AppAuthConfig{
+		AppID:               "12345",
+		PrivateKey:          privateKeyPEM,
+		AllowedBaseURLHosts: []string{serverURL.Hostname()},
+	}, logging.NewLogger())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	installationID, err := client.VerifyInstallation(context.Background(), &code.GitHubSetting{
 		Type:           code.Type_ORGANIZATION,
 		TargetResource: "target",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
 	})
-	if err == nil {
-		t.Fatal("Expected error but got none")
-	}
-	if err.Error() != "installation_id does not match target resource" {
+	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if strings.Contains(err.Error(), "99999") || strings.Contains(err.Error(), "12345") {
-		t.Fatalf("Error exposes installation_id: %v", err)
+	if !gotCreateToken {
+		t.Fatal("Expected create token call with resolved installation_id")
+	}
+	if installationID != 99999 {
+		t.Fatalf("Unexpected installation_id: want=99999, got=%d", installationID)
 	}
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -24,7 +24,7 @@ type GithubServiceClient interface {
 	Clone(ctx context.Context, token string, cloneURL string, dstDir string) error
 	SupportsGitHubApp() bool
 	ResolveInstallationToken(ctx context.Context, config *code.GitHubSetting, repoName string) (string, error)
-	VerifyInstallation(ctx context.Context, config *code.GitHubSetting) error
+	VerifyInstallation(ctx context.Context, config *code.GitHubSetting) (uint64, error)
 	VerifyUserToServer(ctx context.Context, config *code.GitHubSetting, oauthCode string) (string, error)
 }
 

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -338,7 +338,28 @@ func (c *CodeService) PutGitHubSetting(ctx context.Context, req *code.PutGitHubS
 	if err != nil {
 		return nil, err
 	}
+	if registeredGitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
+		registeredGitHubSetting, err = c.updateGitHubAppInstallationVerification(ctx, registeredGitHubSetting)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &code.PutGitHubSettingResponse{GithubSetting: convertGitHubSetting(registeredGitHubSetting, nil, nil, nil, true)}, nil
+}
+
+func (c *CodeService) updateGitHubAppInstallationVerification(ctx context.Context, githubSetting *model.CodeGitHubSetting) (*model.CodeGitHubSetting, error) {
+	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
+	installationID, err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting)
+	if err != nil {
+		c.logger.Warnf(ctx, "Failed to verify github app installation: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, err)
+		failedGitHubSetting, updateErr := c.repository.UpdateGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, code.GitHubVerificationStatusFailed, "", time.Now())
+		if updateErr != nil {
+			c.logger.Errorf(ctx, "Failed to update github app verification failure: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, updateErr)
+			return nil, updateErr
+		}
+		return failedGitHubSetting, nil
+	}
+	return c.repository.UpdateGitHubAppInstallationVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, installationID, code.GitHubVerificationStatusSuccess, githubSetting.GitHubUser, time.Now())
 }
 
 func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code.VerifyGitHubAppInstallationRequest) (*code.VerifyGitHubAppInstallationResponse, error) {

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -352,12 +352,10 @@ func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code
 	if githubSetting.AuthMode != code.GitHubAuthModeGitHubApp {
 		return nil, fmt.Errorf("github setting is not github app auth mode: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
-	if githubSetting.InstallationID == nil || *githubSetting.InstallationID == 0 {
-		return nil, fmt.Errorf("installation_id is required: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
-	}
 
 	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	if err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting); err != nil {
+	installationID, err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting)
+	if err != nil {
 		c.logger.Warnf(ctx, "Failed to verify github app installation: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
 		_, updateErr := c.repository.UpdateGitHubAppVerification(ctx, req.ProjectId, req.GithubSettingId, code.GitHubVerificationStatusFailed, "", time.Now())
 		if updateErr != nil {
@@ -366,7 +364,7 @@ func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code
 		return nil, errors.New("github app installation verification failed")
 	}
 
-	verifiedGitHubSetting, err := c.repository.UpdateGitHubAppVerification(ctx, req.ProjectId, req.GithubSettingId, code.GitHubVerificationStatusSuccess, githubSetting.GitHubUser, time.Now())
+	verifiedGitHubSetting, err := c.repository.UpdateGitHubAppInstallationVerification(ctx, req.ProjectId, req.GithubSettingId, installationID, code.GitHubVerificationStatusSuccess, githubSetting.GitHubUser, time.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -459,12 +459,18 @@ func TestPutGitHubSetting(t *testing.T) {
 	block, err := aes.NewCipher(key)
 	assert.NoError(t, err)
 	cases := []struct {
-		name         string
-		input        *code.PutGitHubSettingRequest
-		want         *code.PutGitHubSettingResponse
-		mockResponse *model.CodeGitHubSetting
-		mockError    error
-		wantErr      bool
+		name                   string
+		input                  *code.PutGitHubSettingRequest
+		want                   *code.PutGitHubSettingResponse
+		mockResponse           *model.CodeGitHubSetting
+		mockError              error
+		githubClientError      error
+		resolvedInstallationID uint64
+		mockUpdateResponse     *model.CodeGitHubSetting
+		mockUpdateError        error
+		wantStatus             string
+		wantVerifiedUser       string
+		wantErr                bool
 	}{
 		{
 			name: "OK",
@@ -484,11 +490,16 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "SUCCESS", VerifiedGithubUser: "octocat", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "SUCCESS", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: "SUCCESS", VerifiedGitHubUser: "octocat", VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
+			mockUpdateResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+			},
+			resolvedInstallationID: installationID,
+			wantStatus:             code.GitHubVerificationStatusSuccess,
 		},
 		{
 			name: "OK github app without installation id",
@@ -496,11 +507,33 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "SUCCESS", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
+			mockUpdateResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+			},
+			resolvedInstallationID: installationID,
+			wantStatus:             code.GitHubVerificationStatusSuccess,
+		},
+		{
+			name: "OK github app verification failed",
+			input: &code.PutGitHubSettingRequest{ProjectId: 1, GithubSetting: &code.GitHubSettingForUpsert{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp},
+			},
+			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: "FAILED", CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+			},
+			mockResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
+			},
+			githubClientError: errors.New("find installation: 404 Not Found"),
+			mockUpdateResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusFailed, CreatedAt: now, UpdatedAt: now,
+			},
+			wantStatus: code.GitHubVerificationStatusFailed,
 		},
 		{
 			name: "OK(empty)",
@@ -532,10 +565,17 @@ func TestPutGitHubSetting(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var ctx context.Context
 			mockDB := mocks.NewCodeRepoInterface(t)
-			svc := CodeService{repository: mockDB, cipherBlock: block, logger: logging.NewLogger()}
+			svc := CodeService{repository: mockDB, githubClient: &FakeGithubClient{err: c.githubClientError, installationID: c.resolvedInstallationID}, cipherBlock: block, logger: logging.NewLogger()}
 
 			if c.mockResponse != nil || c.mockError != nil {
 				mockDB.On("UpsertGitHubSetting", test.RepeatMockAnything(2)...).Return(c.mockResponse, c.mockError).Once()
+			}
+			if c.wantStatus != "" {
+				if c.wantStatus == code.GitHubVerificationStatusSuccess {
+					mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+				} else {
+					mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+				}
 			}
 			got, err := svc.PutGitHubSetting(ctx, c.input)
 			if !c.wantErr && err != nil {

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -491,6 +491,18 @@ func TestPutGitHubSetting(t *testing.T) {
 			},
 		},
 		{
+			name: "OK github app without installation id",
+			input: &code.PutGitHubSettingRequest{ProjectId: 1, GithubSetting: &code.GitHubSettingForUpsert{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp},
+			},
+			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+			},
+			mockResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
+			},
+		},
+		{
 			name: "OK(empty)",
 			input: &code.PutGitHubSettingRequest{ProjectId: 1, GithubSetting: &code.GitHubSettingForUpsert{
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "user", PersonalAccessToken: maskData},
@@ -543,18 +555,19 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 	now := time.Now()
 	installationID := uint64(12345)
 	cases := []struct {
-		name               string
-		input              *code.VerifyGitHubAppInstallationRequest
-		githubClientError  error
-		mockGitHubSetting  *model.CodeGitHubSetting
-		mockGetError       error
-		mockUpdateResponse *model.CodeGitHubSetting
-		mockUpdateError    error
-		want               *code.VerifyGitHubAppInstallationResponse
-		wantErr            bool
-		wantErrMsg         string
-		wantStatus         string
-		wantVerifiedUser   string
+		name                   string
+		input                  *code.VerifyGitHubAppInstallationRequest
+		githubClientError      error
+		mockGitHubSetting      *model.CodeGitHubSetting
+		mockGetError           error
+		mockUpdateResponse     *model.CodeGitHubSetting
+		mockUpdateError        error
+		resolvedInstallationID uint64
+		want                   *code.VerifyGitHubAppInstallationResponse
+		wantErr                bool
+		wantErrMsg             string
+		wantStatus             string
+		wantVerifiedUser       string
 	}{
 		{
 			name:  "OK",
@@ -565,8 +578,25 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 			mockUpdateResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGitHubUser: "octocat", VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
-			wantStatus:       code.GitHubVerificationStatusSuccess,
-			wantVerifiedUser: "octocat",
+			resolvedInstallationID: installationID,
+			wantStatus:             code.GitHubVerificationStatusSuccess,
+			wantVerifiedUser:       "octocat",
+			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGithubUser: "octocat", VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+			}},
+		},
+		{
+			name:  "OK missing installation_id",
+			input: &code.VerifyGitHubAppInstallationRequest{ProjectId: 1, GithubSettingId: 1},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
+			},
+			mockUpdateResponse: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGitHubUser: "octocat", VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
+			},
+			resolvedInstallationID: installationID,
+			wantStatus:             code.GitHubVerificationStatusSuccess,
+			wantVerifiedUser:       "octocat",
 			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGithubUser: "octocat", VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
 			}},
@@ -603,13 +633,17 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			mockDB := mocks.NewCodeRepoInterface(t)
-			svc := CodeService{repository: mockDB, githubClient: &FakeGithubClient{err: c.githubClientError}, logger: logging.NewLogger()}
+			svc := CodeService{repository: mockDB, githubClient: &FakeGithubClient{err: c.githubClientError, installationID: c.resolvedInstallationID}, logger: logging.NewLogger()}
 
 			if c.mockGitHubSetting != nil || c.mockGetError != nil {
 				mockDB.On("GetGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockGitHubSetting, c.mockGetError).Once()
 			}
 			if c.wantStatus != "" {
-				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+				if c.wantStatus == code.GitHubVerificationStatusSuccess {
+					mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+				} else {
+					mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+				}
 			}
 			got, err := svc.VerifyGitHubAppInstallation(context.Background(), c.input)
 			if !c.wantErr && err != nil {
@@ -2324,6 +2358,7 @@ type FakeGithubClient struct {
 	err               error
 	supportsGitHubApp bool
 	verifiedUser      string
+	installationID    uint64
 	gotConfig         *code.GitHubSetting
 	gotRepoName       string
 }
@@ -2353,8 +2388,14 @@ func (g *FakeGithubClient) ResolveInstallationToken(ctx context.Context, config 
 	return "", g.err
 }
 
-func (g *FakeGithubClient) VerifyInstallation(ctx context.Context, config *code.GitHubSetting) error {
-	return g.err
+func (g *FakeGithubClient) VerifyInstallation(ctx context.Context, config *code.GitHubSetting) (uint64, error) {
+	if g.err != nil {
+		return 0, g.err
+	}
+	if g.installationID != 0 {
+		return g.installationID, nil
+	}
+	return config.GetInstallationId(), nil
 }
 
 func (g *FakeGithubClient) VerifyUserToServer(ctx context.Context, config *code.GitHubSetting, oauthCode string) (string, error) {

--- a/proto/code/validator.go
+++ b/proto/code/validator.go
@@ -213,7 +213,6 @@ func (g *GitHubSettingForUpsert) Validate() error {
 		validation.Field(&g.AuthMode, validation.Length(0, 32), validation.In("", GitHubAuthModePersonalAccessToken, GitHubAuthModeGitHubApp)),
 		validation.Field(
 			&g.InstallationId,
-			validation.When(g.AuthMode == GitHubAuthModeGitHubApp, validation.Required),
 			validation.When(g.AuthMode == "" || g.AuthMode == GitHubAuthModePersonalAccessToken, validation.Empty),
 		),
 	)

--- a/proto/code/validator_test.go
+++ b/proto/code/validator_test.go
@@ -676,6 +676,12 @@ func TestValidate_GitHubSettingForUpsert(t *testing.T) {
 			},
 		},
 		{
+			name: "OK auth mode github app without installation id",
+			input: &GitHubSettingForUpsert{
+				ProjectId: 1, Type: Type_ORGANIZATION, TargetResource: "target", AuthMode: GitHubAuthModeGitHubApp,
+			},
+		},
+		{
 			name: "NG Length(name)",
 			input: &GitHubSettingForUpsert{
 				Name: stringLength65, ProjectId: 1, Type: Type_ORGANIZATION, BaseUrl: "https://api.github.com/", TargetResource: "target", GithubUser: "user", PersonalAccessToken: "xxx",
@@ -735,13 +741,6 @@ func TestValidate_GitHubSettingForUpsert(t *testing.T) {
 			name: "NG Invalid(auth_mode)",
 			input: &GitHubSettingForUpsert{
 				ProjectId: 1, Type: Type_ORGANIZATION, TargetResource: "target", AuthMode: "invalid",
-			},
-			wantErr: true,
-		},
-		{
-			name: "NG Required(installation_id for github app)",
-			input: &GitHubSettingForUpsert{
-				ProjectId: 1, Type: Type_ORGANIZATION, TargetResource: "target", AuthMode: GitHubAuthModeGitHubApp,
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## 概要
GitHub Appを管理者による事前インストール方式にする上での変更です。
installation IDはユーザー入力ではなく、GitHub APIから得られる値を自動解決する方がUXが良いと思ったため、GitHub 設定保存時にinstallation_idが未入力でもGitHub Appモードを保存できる設計にします。
検証時にはtarget_resource/typeからGitHub App installationをServer-to-Serverで解決し、GitHub側で取得したinstallation_idを正としてDBへ保存します。

```mermaid
sequenceDiagram
    participant API as datasource-api
    participant DB as DB
    participant GitHub as GitHub API

    API->>DB: UpsertGitHubSetting
    DB-->>API: 保存済みGitHub設定

    alt auth_mode = github_app
        API->>GitHub: installationを検索<br/>target_resource / type
        GitHub-->>API: installation_id

        API->>GitHub: installation token発行
        GitHub-->>API: token発行成功

        API->>DB: installation_id + SUCCESS を保存
        DB-->>API: 更新後GitHub設定を完了
    else 検証失敗
        API->>DB: FAILED を保存
        DB-->>API: 更新後GitHub設定を完了
    end
```

## 影響範囲
- GitHub AppモードのGitHub設定保存時にinstallation_id未入力を許容します。PATモードでは引き続きinstallation_idを空にする必要があります。
- VerifyGitHubAppInstallation成功時に、GitHub APIで解決したinstallation_idを保存します。既存のスキャン処理やPAT認証経路には直接触れていません。
- GitHub App installationが見つからない、またはinstallation tokenを発行できない場合は従来通り検証失敗になります。