### PR TITLE
GitHub App検証後にRepository一覧を同期する

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -24,6 +24,7 @@ type CodeRepoInterface interface {
 	UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
 	CompleteGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, repositories []*code.GitHubAppSettingRepositoryForUpsert, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error)
 	ListGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error)
+	DeleteGitHubAppSettingRepository(ctx context.Context, githubSettingID uint32) error
 	DeleteGitHubSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
 	// code_gitleaks_setting
@@ -433,6 +434,13 @@ func (c *Client) ListGitHubAppSettingRepository(ctx context.Context, projectID, 
 		return nil, err
 	}
 	return &data, nil
+}
+
+func (c *Client) DeleteGitHubAppSettingRepository(ctx context.Context, githubSettingID uint32) error {
+	if err := c.MasterDB.WithContext(ctx).Where("code_github_setting_id = ?", githubSettingID).Delete(&model.GitHubAppSettingRepository{}).Error; err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *Client) UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -22,6 +22,8 @@ type CodeRepoInterface interface {
 	UpsertGitHubSetting(ctx context.Context, data *code.GitHubSettingForUpsert) (*model.CodeGitHubSetting, error)
 	UpdateGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
 	UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
+	CompleteGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, repositories []*code.GitHubAppSettingRepositoryForUpsert, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error)
+	ListGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error)
 	DeleteGitHubSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
 	// code_gitleaks_setting
@@ -315,6 +317,30 @@ WHERE project_id = ?
 	AND auth_mode = ?
 `
 
+const deleteGitHubAppSettingRepository = `
+DELETE FROM ghapp_setting_repository
+WHERE code_github_setting_id = ?
+`
+
+const insertGitHubAppSettingRepository = `
+INSERT INTO ghapp_setting_repository (
+  code_github_setting_id,
+  github_repository_id,
+  github_repository_full_name
+)
+VALUES (?, ?, ?)
+`
+
+const selectListGitHubAppSettingRepository = `
+select
+  repo.*
+from
+  ghapp_setting_repository repo
+  inner join code_github_setting github using(code_github_setting_id)
+where
+  github.project_id = ?
+`
+
 func (c *Client) UpdateGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {
 	result := c.MasterDB.WithContext(ctx).Exec(updateGitHubAppVerification,
 		verificationStatus,
@@ -332,6 +358,81 @@ func (c *Client) UpdateGitHubAppVerification(ctx context.Context, projectID, git
 		return nil, fmt.Errorf("github app verification was not updated: project_id=%d, github_setting_id=%d", projectID, githubSettingID)
 	}
 	return c.GetGitHubSetting(ctx, projectID, githubSettingID)
+}
+
+func (c *Client) CompleteGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, repositories []*code.GitHubAppSettingRepositoryForUpsert, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error) {
+	if installationID == 0 {
+		return nil, nil, errors.New("installation_id is required")
+	}
+	for _, repo := range repositories {
+		if repo == nil {
+			return nil, nil, errors.New("github app setting repository is required")
+		}
+		if repo.GithubSettingId != githubSettingID {
+			return nil, nil, fmt.Errorf("github setting id does not match: github_setting_id=%d, repository_github_setting_id=%d", githubSettingID, repo.GithubSettingId)
+		}
+		if err := repo.Validate(); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var gitHubSetting model.CodeGitHubSetting
+	var gitHubAppRepositories []model.GitHubAppSettingRepository
+	err := c.MasterDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Exec(updateGitHubAppInstallationVerification,
+			installationID,
+			code.GitHubVerificationStatusSuccess,
+			code.GitHubVerificationStatusSuccess,
+			code.GitHubVerificationStatusSuccess,
+			convertZeroValueToNull(verifiedGitHubUser),
+			verifiedAt,
+			projectID,
+			githubSettingID,
+			code.GitHubAuthModeGitHubApp)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("github app installation verification was not updated: project_id=%d, github_setting_id=%d", projectID, githubSettingID)
+		}
+		if err := tx.Exec(deleteGitHubAppSettingRepository, githubSettingID).Error; err != nil {
+			return err
+		}
+		for _, repo := range repositories {
+			if err := tx.Exec(insertGitHubAppSettingRepository,
+				repo.GithubSettingId,
+				repo.GithubRepositoryId,
+				repo.GithubRepositoryFullName).Error; err != nil {
+				return err
+			}
+		}
+		if err := tx.Where("project_id = ? AND code_github_setting_id = ?", projectID, githubSettingID).First(&gitHubSetting).Error; err != nil {
+			return err
+		}
+		query := selectListGitHubAppSettingRepository + " and repo.code_github_setting_id = ?"
+		if err := tx.Raw(query, projectID, githubSettingID).Scan(&gitHubAppRepositories).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &gitHubSetting, &gitHubAppRepositories, nil
+}
+
+func (c *Client) ListGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error) {
+	query := selectListGitHubAppSettingRepository
+	params := []any{projectID}
+	if githubSettingID != 0 {
+		query += " and repo.code_github_setting_id = ?"
+		params = append(params, githubSettingID)
+	}
+	data := []model.GitHubAppSettingRepository{}
+	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
+		return nil, err
+	}
+	return &data, nil
 }
 
 func (c *Client) UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error) {

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -621,6 +621,54 @@ func TestListGitHubAppSettingRepository(t *testing.T) {
 	}
 }
 
+func TestDeleteGitHubAppSettingRepository(t *testing.T) {
+	cases := []struct {
+		name        string
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:    "OK",
+			wantErr: false,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `ghapp_setting_repository` WHERE code_github_setting_id = ?")).
+					WithArgs(uint32(1)).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name:    "NG DB error",
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `ghapp_setting_repository` WHERE code_github_setting_id = ?")).
+					WithArgs(uint32(1)).
+					WillReturnError(errors.New("DB error"))
+				mock.ExpectRollback()
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			err = db.DeleteGitHubAppSettingRepository(ctx, 1)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
 func TestDeleteGitHubSetting(t *testing.T) {
 	type args struct {
 		ProjectID           uint32

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -430,6 +430,197 @@ func TestUpdateGitHubAppInstallationVerification(t *testing.T) {
 	}
 }
 
+func TestCompleteGitHubAppVerification(t *testing.T) {
+	now := time.Now()
+	installationID := uint64(12345)
+	repositories := []*code.GitHubAppSettingRepositoryForUpsert{
+		{GithubSettingId: 1, GithubRepositoryId: 67890, GithubRepositoryFullName: "owner/repo"},
+	}
+	wantSetting := &model.CodeGitHubSetting{
+		CodeGitHubSettingID: 1,
+		ProjectID:           1,
+		InstallationID:      &installationID,
+		AuthMode:            code.GitHubAuthModeGitHubApp,
+		VerificationStatus:  code.GitHubVerificationStatusSuccess,
+		VerifiedGitHubUser:  "octocat",
+		VerifiedAt:          now,
+	}
+	wantRepositories := &[]model.GitHubAppSettingRepository{
+		{
+			GitHubAppSettingRepositoryID: 10,
+			CodeGitHubSettingID:          1,
+			GitHubRepositoryID:           67890,
+			GitHubRepositoryFullName:     "owner/repo",
+			CreatedAt:                    now,
+			UpdatedAt:                    now,
+		},
+	}
+	cases := []struct {
+		name        string
+		inputRepos  []*code.GitHubAppSettingRepositoryForUpsert
+		wantSetting *model.CodeGitHubSetting
+		wantRepos   *[]model.GitHubAppSettingRepository
+		wantErr     bool
+		mockClosure func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name:        "OK",
+			inputRepos:  repositories,
+			wantSetting: wantSetting,
+			wantRepos:   wantRepositories,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
+					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec(regexp.QuoteMeta(deleteGitHubAppSettingRepository)).
+					WithArgs(uint32(1)).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec(regexp.QuoteMeta(insertGitHubAppSettingRepository)).
+					WithArgs(uint32(1), uint64(67890), "owner/repo").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).
+					WillReturnRows(sqlmock.NewRows([]string{
+						"code_github_setting_id", "project_id", "installation_id", "auth_mode", "verification_status", "verified_github_user", "verified_at"}).
+						AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusSuccess, "octocat", now))
+				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository+" and repo.code_github_setting_id = ?")).
+					WithArgs(uint32(1), uint32(1)).
+					WillReturnRows(sqlmock.NewRows([]string{
+						"ghapp_setting_repository_id", "code_github_setting_id", "github_repository_id", "github_repository_full_name", "created_at", "updated_at"}).
+						AddRow(uint32(10), uint32(1), uint64(67890), "owner/repo", now, now))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name:       "NG installation_id is zero",
+			inputRepos: repositories,
+			wantErr:    true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+			},
+		},
+		{
+			name: "NG github setting id mismatch",
+			inputRepos: []*code.GitHubAppSettingRepositoryForUpsert{
+				{GithubSettingId: 2, GithubRepositoryId: 67890, GithubRepositoryFullName: "owner/repo"},
+			},
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+			},
+		},
+		{
+			name:       "NG no rows updated",
+			inputRepos: repositories,
+			wantErr:    true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
+					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WillReturnResult(sqlmock.NewResult(1, 0))
+				mock.ExpectRollback()
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			inputInstallationID := installationID
+			if c.name == "NG installation_id is zero" {
+				inputInstallationID = 0
+			}
+			gotSetting, gotRepos, err := db.CompleteGitHubAppVerification(ctx, 1, 1, inputInstallationID, c.inputRepos, "octocat", now)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(gotSetting, c.wantSetting) {
+				t.Fatalf("Unexpected setting mapping: want=%+v, got=%+v", c.wantSetting, gotSetting)
+			}
+			if !reflect.DeepEqual(gotRepos, c.wantRepos) {
+				t.Fatalf("Unexpected repository mapping: want=%+v, got=%+v", c.wantRepos, gotRepos)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestListGitHubAppSettingRepository(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name            string
+		githubSettingID uint32
+		want            *[]model.GitHubAppSettingRepository
+		wantErr         bool
+		mockClosure     func(mock sqlmock.Sqlmock)
+	}{
+		{
+			name: "OK list all repositories in project",
+			want: &[]model.GitHubAppSettingRepository{
+				{
+					GitHubAppSettingRepositoryID: 10,
+					CodeGitHubSettingID:          1,
+					GitHubRepositoryID:           67890,
+					GitHubRepositoryFullName:     "owner/repo",
+					CreatedAt:                    now,
+					UpdatedAt:                    now,
+				},
+			},
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository)).
+					WithArgs(uint32(1)).
+					WillReturnRows(sqlmock.NewRows([]string{
+						"ghapp_setting_repository_id", "code_github_setting_id", "github_repository_id", "github_repository_full_name", "created_at", "updated_at"}).
+						AddRow(uint32(10), uint32(1), uint64(67890), "owner/repo", now, now))
+			},
+		},
+		{
+			name:            "OK list repositories by github setting",
+			githubSettingID: 1,
+			want:            &[]model.GitHubAppSettingRepository{},
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository+" and repo.code_github_setting_id = ?")).
+					WithArgs(uint32(1), uint32(1)).
+					WillReturnRows(sqlmock.NewRows([]string{
+						"ghapp_setting_repository_id", "code_github_setting_id", "github_repository_id", "github_repository_full_name", "created_at", "updated_at"}))
+			},
+		},
+		{
+			name:    "NG DB error",
+			wantErr: true,
+			mockClosure: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository)).
+					WithArgs(uint32(1)).
+					WillReturnError(errors.New("DB error"))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, mock, err := newDBMock()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+			c.mockClosure(mock)
+			got, err := db.ListGitHubAppSettingRepository(ctx, 1, c.githubSettingID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
 func TestDeleteGitHubSetting(t *testing.T) {
 	type args struct {
 		ProjectID           uint32

--- a/pkg/db/mocks/CodeRepoInterface.go
+++ b/pkg/db/mocks/CodeRepoInterface.go
@@ -110,6 +110,24 @@ func (_m *CodeRepoInterface) DeleteGitHubSetting(ctx context.Context, projectID 
 	return r0
 }
 
+// DeleteGitHubAppSettingRepository provides a mock function with given fields: ctx, githubSettingID
+func (_m *CodeRepoInterface) DeleteGitHubAppSettingRepository(ctx context.Context, githubSettingID uint32) error {
+	ret := _m.Called(ctx, githubSettingID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteGitHubAppSettingRepository")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32) error); ok {
+		r0 = rf(ctx, githubSettingID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteGitleaksCache provides a mock function with given fields: ctx, githubSettingID
 func (_m *CodeRepoInterface) DeleteGitleaksCache(ctx context.Context, githubSettingID uint32) error {
 	ret := _m.Called(ctx, githubSettingID)

--- a/pkg/db/mocks/CodeRepoInterface.go
+++ b/pkg/db/mocks/CodeRepoInterface.go
@@ -314,6 +314,36 @@ func (_m *CodeRepoInterface) GetGitHubSetting(ctx context.Context, projectID uin
 	return r0, r1
 }
 
+// ListGitHubAppSettingRepository provides a mock function with given fields: ctx, projectID, githubSettingID
+func (_m *CodeRepoInterface) ListGitHubAppSettingRepository(ctx context.Context, projectID uint32, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error) {
+	ret := _m.Called(ctx, projectID, githubSettingID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListGitHubAppSettingRepository")
+	}
+
+	var r0 *[]model.GitHubAppSettingRepository
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) (*[]model.GitHubAppSettingRepository, error)); ok {
+		return rf(ctx, projectID, githubSettingID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) *[]model.GitHubAppSettingRepository); ok {
+		r0 = rf(ctx, projectID, githubSettingID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*[]model.GitHubAppSettingRepository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32) error); ok {
+		r1 = rf(ctx, projectID, githubSettingID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetGitleaksCache provides a mock function with given fields: ctx, projectID, githubSettingID, repositoryFullName, immediately
 func (_m *CodeRepoInterface) GetGitleaksCache(ctx context.Context, projectID uint32, githubSettingID uint32, repositoryFullName string, immediately bool) (*model.CodeGitleaksCache, error) {
 	ret := _m.Called(ctx, projectID, githubSettingID, repositoryFullName, immediately)
@@ -966,6 +996,45 @@ func (_m *CodeRepoInterface) UpdateGitHubAppInstallationVerification(ctx context
 	}
 
 	return r0, r1
+}
+
+// CompleteGitHubAppVerification provides a mock function with given fields: ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt
+func (_m *CodeRepoInterface) CompleteGitHubAppVerification(ctx context.Context, projectID uint32, githubSettingID uint32, installationID uint64, repositories []*code.GitHubAppSettingRepositoryForUpsert, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error) {
+	ret := _m.Called(ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompleteGitHubAppVerification")
+	}
+
+	var r0 *model.CodeGitHubSetting
+	var r1 *[]model.GitHubAppSettingRepository
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, uint64, []*code.GitHubAppSettingRepositoryForUpsert, string, time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error)); ok {
+		return rf(ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, uint64, []*code.GitHubAppSettingRepositoryForUpsert, string, time.Time) *model.CodeGitHubSetting); ok {
+		r0 = rf(ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.CodeGitHubSetting)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32, uint64, []*code.GitHubAppSettingRepositoryForUpsert, string, time.Time) *[]model.GitHubAppSettingRepository); ok {
+		r1 = rf(ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*[]model.GitHubAppSettingRepository)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, uint32, uint32, uint64, []*code.GitHubAppSettingRepositoryForUpsert, string, time.Time) error); ok {
+		r2 = rf(ctx, projectID, githubSettingID, installationID, repositories, verifiedGitHubUser, verifiedAt)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // UpsertGitleaksCache provides a mock function with given fields: ctx, projectID, data

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -123,6 +123,7 @@ const maskData = "xxxxxxxxxx"
 
 func convertGitHubSetting(
 	gitHubSetting *model.CodeGitHubSetting,
+	gitHubAppRepositories *[]model.GitHubAppSettingRepository,
 	gitleaksSetting *model.CodeGitleaksSetting,
 	dependencySetting *model.CodeDependencySetting,
 	codeScanSetting *model.CodeCodeScanSetting,
@@ -165,8 +166,28 @@ func convertGitHubSetting(
 	if codeScanSetting != nil {
 		convertedGithubSetting.CodeScanSetting = convertCodeScanSetting(codeScanSetting)
 	}
+	if gitHubAppRepositories != nil {
+		for _, repo := range *gitHubAppRepositories {
+			convertedGithubSetting.GithubAppSettingRepository = append(convertedGithubSetting.GithubAppSettingRepository, convertGitHubAppSettingRepository(&repo))
+		}
+	}
 	return &convertedGithubSetting
 }
+
+func convertGitHubAppSettingRepository(data *model.GitHubAppSettingRepository) *code.GitHubAppSettingRepository {
+	var converted code.GitHubAppSettingRepository
+	if data == nil {
+		return &converted
+	}
+	return &code.GitHubAppSettingRepository{
+		GithubSettingId:          data.CodeGitHubSettingID,
+		GithubRepositoryId:       data.GitHubRepositoryID,
+		GithubRepositoryFullName: data.GitHubRepositoryFullName,
+		CreatedAt:                data.CreatedAt.Unix(),
+		UpdatedAt:                data.UpdatedAt.Unix(),
+	}
+}
+
 func convertGitleaksSetting(data *model.CodeGitleaksSetting) *code.GitleaksSetting {
 	var gitleaksSetting code.GitleaksSetting
 	if data == nil {
@@ -260,6 +281,10 @@ func (c *CodeService) ListGitHubSetting(ctx context.Context, req *code.ListGitHu
 	if err != nil {
 		return nil, err
 	}
+	gitHubAppRepositories, err := c.repository.ListGitHubAppSettingRepository(ctx, req.ProjectId, req.GithubSettingId)
+	if err != nil {
+		return nil, err
+	}
 	mapGitleaksSetting := map[uint32]model.CodeGitleaksSetting{}
 	for _, gitleaksSetting := range *gitleaksSettings {
 		mapGitleaksSetting[gitleaksSetting.CodeGitHubSettingID] = gitleaksSetting
@@ -272,11 +297,16 @@ func (c *CodeService) ListGitHubSetting(ctx context.Context, req *code.ListGitHu
 	for _, codeScanSetting := range *codeScanSettings {
 		mapCodeScanSetting[codeScanSetting.CodeGitHubSettingID] = codeScanSetting
 	}
+	mapGitHubAppRepositories := map[uint32][]model.GitHubAppSettingRepository{}
+	for _, repo := range *gitHubAppRepositories {
+		mapGitHubAppRepositories[repo.CodeGitHubSettingID] = append(mapGitHubAppRepositories[repo.CodeGitHubSettingID], repo)
+	}
 
 	for _, gitHubSetting := range *gitHubSettings {
 		var gitleaks *model.CodeGitleaksSetting
 		var dependency *model.CodeDependencySetting
 		var codescan *model.CodeCodeScanSetting
+		var ghappRepositories *[]model.GitHubAppSettingRepository
 		valGitleaks, ok := mapGitleaksSetting[gitHubSetting.CodeGitHubSettingID]
 		if ok {
 			gitleaks = &valGitleaks
@@ -289,7 +319,11 @@ func (c *CodeService) ListGitHubSetting(ctx context.Context, req *code.ListGitHu
 		if ok {
 			codescan = &valCodeScan
 		}
-		data.GithubSetting = append(data.GithubSetting, convertGitHubSetting(&gitHubSetting, gitleaks, dependency, codescan, true))
+		valGitHubAppRepositories, ok := mapGitHubAppRepositories[gitHubSetting.CodeGitHubSettingID]
+		if ok {
+			ghappRepositories = &valGitHubAppRepositories
+		}
+		data.GithubSetting = append(data.GithubSetting, convertGitHubSetting(&gitHubSetting, ghappRepositories, gitleaks, dependency, codescan, true))
 	}
 	return &data, nil
 }
@@ -317,7 +351,11 @@ func (c *CodeService) GetGitHubSetting(ctx context.Context, req *code.GetGitHubS
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
-	return &code.GetGitHubSettingResponse{GithubSetting: convertGitHubSetting(githubSetting, gitleaksSetting, dependencySetting, codeScanSetting, false)}, nil
+	gitHubAppRepositories, err := c.repository.ListGitHubAppSettingRepository(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID)
+	if err != nil {
+		return nil, err
+	}
+	return &code.GetGitHubSettingResponse{GithubSetting: convertGitHubSetting(githubSetting, gitHubAppRepositories, gitleaksSetting, dependencySetting, codeScanSetting, false)}, nil
 }
 
 func (c *CodeService) PutGitHubSetting(ctx context.Context, req *code.PutGitHubSettingRequest) (*code.PutGitHubSettingResponse, error) {
@@ -338,28 +376,67 @@ func (c *CodeService) PutGitHubSetting(ctx context.Context, req *code.PutGitHubS
 	if err != nil {
 		return nil, err
 	}
+	var gitHubAppRepositories *[]model.GitHubAppSettingRepository
 	if registeredGitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
-		registeredGitHubSetting, err = c.updateGitHubAppInstallationVerification(ctx, registeredGitHubSetting)
+		registeredGitHubSetting, gitHubAppRepositories, err = c.updateGitHubAppInstallationVerification(ctx, registeredGitHubSetting)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return &code.PutGitHubSettingResponse{GithubSetting: convertGitHubSetting(registeredGitHubSetting, nil, nil, nil, true)}, nil
+	return &code.PutGitHubSettingResponse{GithubSetting: convertGitHubSetting(registeredGitHubSetting, gitHubAppRepositories, nil, nil, nil, true)}, nil
 }
 
-func (c *CodeService) updateGitHubAppInstallationVerification(ctx context.Context, githubSetting *model.CodeGitHubSetting) (*model.CodeGitHubSetting, error) {
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	installationID, err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting)
+func (c *CodeService) updateGitHubAppInstallationVerification(ctx context.Context, githubSetting *model.CodeGitHubSetting) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error) {
+	verifiedGitHubSetting, gitHubAppRepositories, err := c.completeGitHubAppInstallationVerification(ctx, githubSetting)
 	if err != nil {
 		c.logger.Warnf(ctx, "Failed to verify github app installation: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, err)
 		failedGitHubSetting, updateErr := c.repository.UpdateGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, code.GitHubVerificationStatusFailed, "", time.Now())
 		if updateErr != nil {
 			c.logger.Errorf(ctx, "Failed to update github app verification failure: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, updateErr)
-			return nil, updateErr
+			return nil, nil, updateErr
 		}
-		return failedGitHubSetting, nil
+		return failedGitHubSetting, nil, nil
 	}
-	return c.repository.UpdateGitHubAppInstallationVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, installationID, code.GitHubVerificationStatusSuccess, githubSetting.GitHubUser, time.Now())
+	return verifiedGitHubSetting, gitHubAppRepositories, nil
+}
+
+func (c *CodeService) completeGitHubAppInstallationVerification(ctx context.Context, githubSetting *model.CodeGitHubSetting) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error) {
+	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, nil, false)
+	installationID, err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting)
+	if err != nil {
+		return nil, nil, err
+	}
+	protoGitHubSetting.InstallationId = installationID
+	repositories, err := c.githubClient.ListRepository(ctx, protoGitHubSetting, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("list github app repositories: %w", err)
+	}
+	repositoriesForUpsert, err := buildGitHubAppSettingRepositoryForUpsert(githubSetting.CodeGitHubSettingID, repositories)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.repository.CompleteGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, installationID, repositoriesForUpsert, githubSetting.GitHubUser, time.Now())
+}
+
+func buildGitHubAppSettingRepositoryForUpsert(githubSettingID uint32, repositories []*ghub.Repository) ([]*code.GitHubAppSettingRepositoryForUpsert, error) {
+	repositoriesForUpsert := []*code.GitHubAppSettingRepositoryForUpsert{}
+	for _, repo := range repositories {
+		if repo == nil {
+			continue
+		}
+		if repo.GetID() == 0 {
+			return nil, fmt.Errorf("github repository id is empty: github_setting_id=%d", githubSettingID)
+		}
+		if repo.GetFullName() == "" {
+			return nil, fmt.Errorf("github repository full name is empty: github_setting_id=%d, github_repository_id=%d", githubSettingID, repo.GetID())
+		}
+		repositoriesForUpsert = append(repositoriesForUpsert, &code.GitHubAppSettingRepositoryForUpsert{
+			GithubSettingId:          githubSettingID,
+			GithubRepositoryId:       uint64(repo.GetID()),
+			GithubRepositoryFullName: repo.GetFullName(),
+		})
+	}
+	return repositoriesForUpsert, nil
 }
 
 func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code.VerifyGitHubAppInstallationRequest) (*code.VerifyGitHubAppInstallationResponse, error) {
@@ -374,8 +451,7 @@ func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code
 		return nil, fmt.Errorf("github setting is not github app auth mode: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
 
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
-	installationID, err := c.githubClient.VerifyInstallation(ctx, protoGitHubSetting)
+	verifiedGitHubSetting, gitHubAppRepositories, err := c.completeGitHubAppInstallationVerification(ctx, githubSetting)
 	if err != nil {
 		c.logger.Warnf(ctx, "Failed to verify github app installation: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
 		_, updateErr := c.repository.UpdateGitHubAppVerification(ctx, req.ProjectId, req.GithubSettingId, code.GitHubVerificationStatusFailed, "", time.Now())
@@ -385,11 +461,7 @@ func (c *CodeService) VerifyGitHubAppInstallation(ctx context.Context, req *code
 		return nil, errors.New("github app installation verification failed")
 	}
 
-	verifiedGitHubSetting, err := c.repository.UpdateGitHubAppInstallationVerification(ctx, req.ProjectId, req.GithubSettingId, installationID, code.GitHubVerificationStatusSuccess, githubSetting.GitHubUser, time.Now())
-	if err != nil {
-		return nil, err
-	}
-	return &code.VerifyGitHubAppInstallationResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, nil, nil, nil, true)}, nil
+	return &code.VerifyGitHubAppInstallationResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, gitHubAppRepositories, nil, nil, nil, true)}, nil
 }
 
 func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyGitHubAppUserRequest) (*code.VerifyGitHubAppUserResponse, error) {
@@ -407,7 +479,7 @@ func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyG
 		return nil, fmt.Errorf("installation_id is required: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
 
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, false)
+	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, nil, false)
 	verifiedUser, err := c.githubClient.VerifyUserToServer(ctx, protoGitHubSetting, req.Code)
 	if err != nil {
 		c.logger.Warnf(ctx, "Failed to verify github app user: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
@@ -427,7 +499,7 @@ func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyG
 	if err != nil {
 		return nil, err
 	}
-	return &code.VerifyGitHubAppUserResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, nil, nil, nil, true)}, nil
+	return &code.VerifyGitHubAppUserResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, nil, nil, nil, nil, true)}, nil
 }
 
 func (c *CodeService) DeleteGitHubSetting(ctx context.Context, req *code.DeleteGitHubSettingRequest) (*empty.Empty, error) {
@@ -1024,7 +1096,7 @@ func (c *CodeService) PutDependencyRepository(ctx context.Context, req *code.Put
 }
 
 func (c *CodeService) buildGitHubSettingForRepositoryList(ctx context.Context, gitHubSetting *model.CodeGitHubSetting, projectID, githubSettingID uint32) (*code.GitHubSetting, error) {
-	protoGitHubSetting := convertGitHubSetting(gitHubSetting, nil, nil, nil, false)
+	protoGitHubSetting := convertGitHubSetting(gitHubSetting, nil, nil, nil, nil, false)
 	if gitHubSetting.AuthMode == code.GitHubAuthModeGitHubApp {
 		if gitHubSetting.VerificationStatus != code.GitHubVerificationStatusSuccess {
 			return nil, fmt.Errorf("github app installation is not verified: project_id=%d, github_setting_id=%d", projectID, githubSettingID)

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -518,6 +518,9 @@ func (c *CodeService) DeleteGitHubSetting(ctx context.Context, req *code.DeleteG
 	if err := c.repository.DeleteCodeScanSetting(ctx, req.ProjectId, req.GithubSettingId); err != nil {
 		return nil, err
 	}
+	if err := c.repository.DeleteGitHubAppSettingRepository(ctx, req.GithubSettingId); err != nil {
+		return nil, err
+	}
 	if err := c.repository.DeleteGitHubSetting(ctx, req.ProjectId, req.GithubSettingId); err != nil {
 		return nil, err
 	}

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -796,6 +796,9 @@ func TestDeleteGitHubSetting(t *testing.T) {
 		callDeleteCodeScan     bool
 		mockDeleteCodeScanResp error
 
+		callDeleteGitHubAppSettingRepository     bool
+		mockDeleteGitHubAppSettingRepositoryResp error
+
 		callDeleteGithubSetting     bool
 		mockDeleteGithubSettingResp error
 	}{
@@ -815,6 +818,9 @@ func TestDeleteGitHubSetting(t *testing.T) {
 
 			callDeleteCodeScan:     true,
 			mockDeleteCodeScanResp: nil,
+
+			callDeleteGitHubAppSettingRepository:     true,
+			mockDeleteGitHubAppSettingRepositoryResp: nil,
 
 			callDeleteGithubSetting:     true,
 			mockDeleteGithubSettingResp: nil,
@@ -891,8 +897,31 @@ func TestDeleteGitHubSetting(t *testing.T) {
 			callDeleteCodeScan:     true,
 			mockDeleteCodeScanResp: nil,
 
+			callDeleteGitHubAppSettingRepository:     true,
+			mockDeleteGitHubAppSettingRepositoryResp: nil,
+
 			callDeleteGithubSetting:     true,
 			mockDeleteGithubSettingResp: errors.New("something error"),
+		},
+		{
+			name:    "NG DB error (delete github app setting repository)",
+			input:   &code.DeleteGitHubSettingRequest{ProjectId: 1, GithubSettingId: 1},
+			wantErr: true,
+
+			callDeleteGitleaksCache:     true,
+			mockDeleteGitleaksCacheResp: nil,
+
+			callDeleteGitleaks:     true,
+			mockDeleteGitleaksResp: nil,
+
+			callDeleteDependency:     true,
+			mockDeleteDependencyResp: nil,
+
+			callDeleteCodeScan:     true,
+			mockDeleteCodeScanResp: nil,
+
+			callDeleteGitHubAppSettingRepository:     true,
+			mockDeleteGitHubAppSettingRepositoryResp: errors.New("something error"),
 		},
 	}
 	for _, c := range cases {
@@ -912,6 +941,9 @@ func TestDeleteGitHubSetting(t *testing.T) {
 			}
 			if c.callDeleteCodeScan {
 				mockDB.On("DeleteCodeScanSetting", test.RepeatMockAnything(3)...).Return(c.mockDeleteCodeScanResp).Once()
+			}
+			if c.callDeleteGitHubAppSettingRepository {
+				mockDB.On("DeleteGitHubAppSettingRepository", test.RepeatMockAnything(2)...).Return(c.mockDeleteGitHubAppSettingRepositoryResp).Once()
 			}
 			if c.callDeleteGithubSetting {
 				mockDB.On("DeleteGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockDeleteGithubSettingResp).Once()

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -261,6 +261,9 @@ func TestListGitHubSetting(t *testing.T) {
 			if c.mockCodeScanResponse != nil || c.mockCodeScanError != nil {
 				mockDB.On("ListCodeScanSetting", test.RepeatMockAnything(3)...).Return(c.mockCodeScanResponse, c.mockCodeScanError).Once()
 			}
+			if c.mockResponse != nil && len(*c.mockResponse) > 0 && c.mockGitleaksError == nil && c.mockDependencyError == nil && c.mockCodeScanError == nil {
+				mockDB.On("ListGitHubAppSettingRepository", test.RepeatMockAnything(3)...).Return(&[]model.GitHubAppSettingRepository{}, nil).Once()
+			}
 
 			got, err := svc.ListGitHubSetting(ctx, c.input)
 			if !c.wantErr && err != nil {
@@ -436,6 +439,12 @@ func TestGetGitHubSetting(t *testing.T) {
 			if c.mockCodeScanResponse != nil || c.mockCodeScanError != nil {
 				mockDB.On("GetCodeScanSetting", test.RepeatMockAnything(3)...).Return(c.mockCodeScanResponse, c.mockCodeScanError).Once()
 			}
+			if c.mockResponse != nil &&
+				(c.mockGitleaksError == nil || errors.Is(c.mockGitleaksError, gorm.ErrRecordNotFound)) &&
+				(c.mockDependencyError == nil || errors.Is(c.mockDependencyError, gorm.ErrRecordNotFound)) &&
+				(c.mockCodeScanError == nil || errors.Is(c.mockCodeScanError, gorm.ErrRecordNotFound)) {
+				mockDB.On("ListGitHubAppSettingRepository", test.RepeatMockAnything(3)...).Return(&[]model.GitHubAppSettingRepository{}, nil).Once()
+			}
 
 			got, err := svc.GetGitHubSetting(ctx, c.input)
 			if !c.wantErr && err != nil {
@@ -467,6 +476,7 @@ func TestPutGitHubSetting(t *testing.T) {
 		githubClientError      error
 		resolvedInstallationID uint64
 		mockUpdateResponse     *model.CodeGitHubSetting
+		mockRepositoryResponse *[]model.GitHubAppSettingRepository
 		mockUpdateError        error
 		wantStatus             string
 		wantVerifiedUser       string
@@ -572,7 +582,11 @@ func TestPutGitHubSetting(t *testing.T) {
 			}
 			if c.wantStatus != "" {
 				if c.wantStatus == code.GitHubVerificationStatusSuccess {
-					mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+					repositories := c.mockRepositoryResponse
+					if repositories == nil {
+						repositories = &[]model.GitHubAppSettingRepository{}
+					}
+					mockDB.On("CompleteGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, mock.Anything, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, repositories, c.mockUpdateError).Once()
 				} else {
 					mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
 				}
@@ -601,6 +615,7 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 		mockGitHubSetting      *model.CodeGitHubSetting
 		mockGetError           error
 		mockUpdateResponse     *model.CodeGitHubSetting
+		mockRepositoryResponse *[]model.GitHubAppSettingRepository
 		mockUpdateError        error
 		resolvedInstallationID uint64
 		want                   *code.VerifyGitHubAppInstallationResponse
@@ -680,7 +695,11 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 			}
 			if c.wantStatus != "" {
 				if c.wantStatus == code.GitHubVerificationStatusSuccess {
-					mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+					repositories := c.mockRepositoryResponse
+					if repositories == nil {
+						repositories = &[]model.GitHubAppSettingRepository{}
+					}
+					mockDB.On("CompleteGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, mock.Anything, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, repositories, c.mockUpdateError).Once()
 				} else {
 					mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
 				}
@@ -699,6 +718,58 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				if strings.Contains(err.Error(), "/orgs/target/installation") {
 					t.Fatalf("Error exposes GitHub API details: %v", err)
 				}
+			}
+			if !reflect.DeepEqual(c.want, got) {
+				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildGitHubAppSettingRepositoryForUpsert(t *testing.T) {
+	cases := []struct {
+		name            string
+		githubSettingID uint32
+		repositories    []*ghub.Repository
+		want            []*code.GitHubAppSettingRepositoryForUpsert
+		wantErr         bool
+	}{
+		{
+			name:            "OK",
+			githubSettingID: 1,
+			repositories: []*ghub.Repository{
+				{ID: ghub.Int64(12345), FullName: ghub.String("owner/repo")},
+				nil,
+			},
+			want: []*code.GitHubAppSettingRepositoryForUpsert{
+				{GithubSettingId: 1, GithubRepositoryId: 12345, GithubRepositoryFullName: "owner/repo"},
+			},
+		},
+		{
+			name:            "NG repository id is empty",
+			githubSettingID: 1,
+			repositories: []*ghub.Repository{
+				{FullName: ghub.String("owner/repo")},
+			},
+			wantErr: true,
+		},
+		{
+			name:            "NG repository full name is empty",
+			githubSettingID: 1,
+			repositories: []*ghub.Repository{
+				{ID: ghub.Int64(12345)},
+			},
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := buildGitHubAppSettingRepositoryForUpsert(c.githubSettingID, c.repositories)
+			if !c.wantErr && err != nil {
+				t.Fatalf("Unexpected error occured: %+v", err)
+			}
+			if c.wantErr && err == nil {
+				t.Fatalf("Unexpected no error")
 			}
 			if !reflect.DeepEqual(c.want, got) {
 				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)


### PR DESCRIPTION
## PRの概要

GitHub App方式では、Appが対象Organization/Userにインストールされていることだけでなく、GitHub側で許可されているRepository一覧をRISKEN側にも保持する必要があります。これまではServer-to-Server検証でinstallation_idを解決してSUCCESSへ更新するところまでで、GitHub側のRepository許可範囲を `ghapp_setting_repository` に同期していませんでした。本PRでは、GitHub設定保存後の自動検証と明示的なVerifyGitHubAppInstallationの両方で、検証成功後にRepository一覧を取得し、検証ステータス更新とRepository同期を同一トランザクションで完了するようにしています。

```mermaid
flowchart TD
  A["GitHub App設定を保存または再同期"] --> B["Server-to-Serverでinstallation_idを解決"]
  B --> C["installation tokenで許可Repository一覧を取得"]
  C --> D["verification_statusをSUCCESSに更新"]
  D --> E["ghapp_setting_repositoryを削除して再投入"]
  E --> F["更新後のGitHub設定とRepository一覧を返却"]
```

| 条件 | 変更前 | 変更後 |
|---|---|---|
| GitHub App検証成功時 | installation_idとSUCCESSのみ保存 | installation_id、SUCCESS、許可Repository一覧を保存 |
| GitHub側の許可Repository変更後 | RISKEN側のRepository一覧に反映されない | 設定再保存または再同期でRISKEN側のRepository一覧を更新 |
| GitHub側からRepository許可を削除 | RISKEN側に同期情報がない | 再同期時にRISKEN側の対象Repositoryからも削除 |

## Other Options

Repository同期方式は、GitHub側の現在状態をRISKEN側へ正確に反映できることを優先して、一括削除・一括同期を採用しています。検討した選択肢は以下です。

| 方式 | メリット | 採用しなかった理由 |
|---|---|---|
| 差分同期 | 追加・削除・renameを個別に処理でき、変更が少ない場合のDB更新量を抑えられる | GitHub側で許可を外したRepositoryの削除漏れが起きると、RISKEN側に古い許可範囲が残る。追加・削除・renameの比較ロジックが増え、複雑になる |
| Upsert中心の同期 | 追加・更新の実装が比較的単純 | GitHub側から削除されたRepositoryを消すには、結局GitHub側の現在一覧とDB一覧の比較が必要になる |
| 一括削除・一括同期 + バッチINSERT | 現在の全置換方針を維持しつつ、大量Repository時のDB往復回数を減らせる | SQL組み立て、バッチサイズ調整、エラー箇所特定などの実装が増える。今回の同期はスキャンごとではなく設定保存・再同期時の処理なので、まずは単純性を優先する |

今回の実装では、削除漏れを避けてGitHub側の許可Repository一覧をそのままRISKEN側へ反映することを重視しています。大量Repositoryで同期時間が問題になる場合は、差分同期より先に、現在の全置換方針を維持したままINSERT部分をバッチ化するのが次の改善候補です。

## レビュー観点例

- [ ] verification_status更新とRepository全置換を同一トランザクションにまとめており、部分更新状態を避ける設計になっている点
- [ ] 差分同期ではなく一括削除・一括同期を採用し、削除漏れ防止と実装単純性を優先している点
- [ ] Repository同期を全削除後の再投入としており、大量Repository時のトランザクション時間が伸びる可能性がある点
- [ ] PutGitHubSetting後の自動検証とVerifyGitHubAppInstallationの明示的再同期が同じ処理を使い、挙動差分を避けている点
- [ ] List/Get GitHubSettingでRepository一覧を追加取得するため、一覧取得時のDBアクセスとレスポンスサイズが増える点
