### PR TITLE
GitHub App user verification uses synced repositories

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -24,6 +24,7 @@ type CodeRepoInterface interface {
 	UpdateGitHubAppInstallationVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, verificationStatus, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, error)
 	CompleteGitHubAppVerification(ctx context.Context, projectID, githubSettingID uint32, installationID uint64, repositories []*code.GitHubAppSettingRepositoryForUpsert, verifiedGitHubUser string, verifiedAt time.Time) (*model.CodeGitHubSetting, *[]model.GitHubAppSettingRepository, error)
 	ListGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error)
+	ListGitHubAppSettingRepositoryImmediately(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error)
 	DeleteGitHubAppSettingRepository(ctx context.Context, githubSettingID uint32) error
 	DeleteGitHubSetting(ctx context.Context, projectID uint32, GitHubSettingID uint32) error
 
@@ -423,6 +424,14 @@ func (c *Client) CompleteGitHubAppVerification(ctx context.Context, projectID, g
 }
 
 func (c *Client) ListGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error) {
+	return c.listGitHubAppSettingRepository(ctx, projectID, githubSettingID, c.SlaveDB)
+}
+
+func (c *Client) ListGitHubAppSettingRepositoryImmediately(ctx context.Context, projectID, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error) {
+	return c.listGitHubAppSettingRepository(ctx, projectID, githubSettingID, c.MasterDB)
+}
+
+func (c *Client) listGitHubAppSettingRepository(ctx context.Context, projectID, githubSettingID uint32, db *gorm.DB) (*[]model.GitHubAppSettingRepository, error) {
 	query := selectListGitHubAppSettingRepository
 	params := []any{projectID}
 	if githubSettingID != 0 {
@@ -430,7 +439,7 @@ func (c *Client) ListGitHubAppSettingRepository(ctx context.Context, projectID, 
 		params = append(params, githubSettingID)
 	}
 	data := []model.GitHubAppSettingRepository{}
-	if err := c.SlaveDB.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
+	if err := db.WithContext(ctx).Raw(query, params...).Scan(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -621,6 +621,39 @@ func TestListGitHubAppSettingRepository(t *testing.T) {
 	}
 }
 
+func TestListGitHubAppSettingRepositoryImmediately(t *testing.T) {
+	now := time.Now()
+	ctx := context.Background()
+	db, mock, err := newDBMock()
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository+" and repo.code_github_setting_id = ?")).
+		WithArgs(uint32(1), uint32(1)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"ghapp_setting_repository_id", "code_github_setting_id", "github_repository_id", "github_repository_full_name", "created_at", "updated_at"}).
+			AddRow(uint32(10), uint32(1), uint64(67890), "owner/repo", now, now))
+
+	got, err := db.ListGitHubAppSettingRepositoryImmediately(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	want := &[]model.GitHubAppSettingRepository{{
+		GitHubAppSettingRepositoryID: 10,
+		CodeGitHubSettingID:          1,
+		GitHubRepositoryID:           67890,
+		GitHubRepositoryFullName:     "owner/repo",
+		CreatedAt:                    now,
+		UpdatedAt:                    now,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Unexpected mapping: want=%+v, got=%+v", want, got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
 func TestDeleteGitHubAppSettingRepository(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/pkg/db/mocks/CodeRepoInterface.go
+++ b/pkg/db/mocks/CodeRepoInterface.go
@@ -632,6 +632,33 @@ func (_m *CodeRepoInterface) ListDependencySetting(ctx context.Context, projectI
 	return r0, r1
 }
 
+// ListGitHubAppSettingRepositoryImmediately provides a mock function with given fields: ctx, projectID, githubSettingID
+func (_m *CodeRepoInterface) ListGitHubAppSettingRepositoryImmediately(ctx context.Context, projectID uint32, githubSettingID uint32) (*[]model.GitHubAppSettingRepository, error) {
+	ret := _m.Called(ctx, projectID, githubSettingID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListGitHubAppSettingRepositoryImmediately")
+	}
+
+	var r0 *[]model.GitHubAppSettingRepository
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32) *[]model.GitHubAppSettingRepository); ok {
+		r0 = rf(ctx, projectID, githubSettingID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*[]model.GitHubAppSettingRepository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, uint32) error); ok {
+		r1 = rf(ctx, projectID, githubSettingID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListGitHubSetting provides a mock function with given fields: ctx, projectID, githubSettingID
 func (_m *CodeRepoInterface) ListGitHubSetting(ctx context.Context, projectID uint32, githubSettingID uint32) (*[]model.CodeGitHubSetting, error) {
 	ret := _m.Called(ctx, projectID, githubSettingID)

--- a/pkg/github/app_auth.go
+++ b/pkg/github/app_auth.go
@@ -154,12 +154,9 @@ func (g *riskenGitHubClient) VerifyUserToServer(ctx context.Context, config *cod
 		return login, nil
 	}
 
-	repositories, err := g.ListRepository(ctx, config, "")
+	repositories, err := buildGitHubRepositoriesFromSetting(config.GetGithubAppSettingRepository())
 	if err != nil {
-		return login, fmt.Errorf("list github app repositories: %w", err)
-	}
-	if len(repositories) == 0 {
-		return login, errors.New("github app repository is required")
+		return login, err
 	}
 
 	isInstallationAdmin, err := g.hasGitHubUserInstallationAdmin(ctx, token, config, login)
@@ -174,6 +171,24 @@ func (g *riskenGitHubClient) VerifyUserToServer(ctx context.Context, config *cod
 		return login, err
 	}
 	return login, nil
+}
+
+func buildGitHubRepositoriesFromSetting(repositories []*code.GitHubAppSettingRepository) ([]*ghub.Repository, error) {
+	if len(repositories) == 0 {
+		return nil, errors.New("github app repository is required")
+	}
+	ghubRepositories := make([]*ghub.Repository, 0, len(repositories))
+	for _, repo := range repositories {
+		if repo == nil {
+			return nil, errors.New("github app repository is required")
+		}
+		fullName := repo.GetGithubRepositoryFullName()
+		if fullName == "" {
+			return nil, errors.New("github repository full name is required")
+		}
+		ghubRepositories = append(ghubRepositories, &ghub.Repository{FullName: ghub.String(fullName)})
+	}
+	return ghubRepositories, nil
 }
 
 func (g *riskenGitHubClient) hasGitHubUserInstallationAdmin(ctx context.Context, token *oauth2.Token, config *code.GitHubSetting, login string) (bool, error) {

--- a/pkg/github/app_auth_test.go
+++ b/pkg/github/app_auth_test.go
@@ -339,7 +339,6 @@ func TestVerifyUserToServer(t *testing.T) {
 	var gotCode string
 	var gotUser bool
 	var gotInstallation bool
-	var gotRepos bool
 	var gotMembership bool
 	var gotPermission bool
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -366,11 +365,6 @@ func TestVerifyUserToServer(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			gotRepos = true
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/repo","owner":{"login":"owner"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/owner/memberships/octocat":
 			gotMembership = true
@@ -415,6 +409,9 @@ func TestVerifyUserToServer(t *testing.T) {
 		TargetResource: "owner",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "owner/repo"},
+		},
 	}, "oauth-code")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -422,8 +419,8 @@ func TestVerifyUserToServer(t *testing.T) {
 	if got != "octocat" {
 		t.Fatalf("Unexpected verified user: %s", got)
 	}
-	if gotCode != "oauth-code" || !gotUser || !gotInstallation || !gotRepos || !gotMembership || !gotPermission {
-		t.Fatalf("Expected oauth/user/installation/repos/membership/permission calls, gotCode=%s, gotUser=%t, gotInstallation=%t, gotRepos=%t, gotMembership=%t, gotPermission=%t", gotCode, gotUser, gotInstallation, gotRepos, gotMembership, gotPermission)
+	if gotCode != "oauth-code" || !gotUser || !gotInstallation || !gotMembership || !gotPermission {
+		t.Fatalf("Expected oauth/user/installation/membership/permission calls, gotCode=%s, gotUser=%t, gotInstallation=%t, gotMembership=%t, gotPermission=%t", gotCode, gotUser, gotInstallation, gotMembership, gotPermission)
 	}
 }
 
@@ -686,10 +683,6 @@ func TestVerifyUserToServerUserTypeSkipsRepositoryPermissionWhenLoginMatches(t *
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
 			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"octocat/repo","owner":{"login":"octocat"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
-			}
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/octocat/repo/collaborators/octocat/permission":
 			gotPermission = true
 			if _, err := w.Write([]byte(`{"permission":"admin"}`)); err != nil {
@@ -728,6 +721,9 @@ func TestVerifyUserToServerUserTypeSkipsRepositoryPermissionWhenLoginMatches(t *
 		TargetResource: "octocat",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "octocat/repo"},
+		},
 	}, "oauth-code")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -762,10 +758,6 @@ func TestVerifyUserToServerSelectedRepositoriesVerifiesOrganizationAdmin(t *test
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/repo","owner":{"login":"owner"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/owner/memberships/octocat":
 			gotMembership = true
@@ -810,6 +802,9 @@ func TestVerifyUserToServerSelectedRepositoriesVerifiesOrganizationAdmin(t *test
 		TargetResource: "owner",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "owner/repo"},
+		},
 	}, "oauth-code")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -846,10 +841,6 @@ func TestVerifyUserToServerSelectedRepositoriesFallsBackToRepositoryAdminWhenOrg
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/repo","owner":{"login":"owner"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/owner/memberships/octocat":
 			w.WriteHeader(http.StatusNotFound)
@@ -894,6 +885,9 @@ func TestVerifyUserToServerSelectedRepositoriesFallsBackToRepositoryAdminWhenOrg
 		TargetResource: "owner",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "owner/repo"},
+		},
 	}, "oauth-code")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -927,10 +921,6 @@ func TestVerifyUserToServerSelectedRepositoriesFallsBackToRepositoryAdminWhenOrg
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/repo","owner":{"login":"owner"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/owner/memberships/octocat":
 			w.WriteHeader(http.StatusForbidden)
@@ -975,6 +965,9 @@ func TestVerifyUserToServerSelectedRepositoriesFallsBackToRepositoryAdminWhenOrg
 		TargetResource: "owner",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "owner/repo"},
+		},
 	}, "oauth-code")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -1007,10 +1000,6 @@ func TestVerifyUserToServerRejectsNonRepositoryAdmin(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":1,"repositories":[{"full_name":"owner/repo","owner":{"login":"owner"}}]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		case r.Method == http.MethodGet && r.URL.Path == "/orgs/owner/memberships/octocat":
 			if _, err := w.Write([]byte(`{"state":"active","role":"member"}`)); err != nil {
@@ -1053,6 +1042,9 @@ func TestVerifyUserToServerRejectsNonRepositoryAdmin(t *testing.T) {
 		TargetResource: "owner",
 		BaseUrl:        server.URL + "/",
 		InstallationId: 12345,
+		GithubAppSettingRepository: []*code.GitHubAppSettingRepository{
+			{GithubRepositoryFullName: "owner/repo"},
+		},
 	}, "oauth-code")
 	if err == nil {
 		t.Fatal("Expected error but got none")
@@ -1082,10 +1074,6 @@ func TestVerifyUserToServerRejectsMissingRepository(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/12345/access_tokens":
 			if _, err := w.Write([]byte(`{"token":"installation-token"}`)); err != nil {
 				t.Fatalf("write installation token response: %v", err)
-			}
-		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
-			if _, err := w.Write([]byte(`{"total_count":0,"repositories":[]}`)); err != nil {
-				t.Fatalf("write repositories response: %v", err)
 			}
 		default:
 			t.Fatalf("Unexpected request: method=%s path=%s", r.Method, r.URL.Path)

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -395,6 +395,10 @@ func (c *CodeService) updateGitHubAppInstallationVerification(ctx context.Contex
 			c.logger.Errorf(ctx, "Failed to update github app verification failure: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, updateErr)
 			return nil, nil, updateErr
 		}
+		if deleteErr := c.repository.DeleteGitHubAppSettingRepository(ctx, githubSetting.CodeGitHubSettingID); deleteErr != nil {
+			c.logger.Errorf(ctx, "Failed to delete github app setting repositories after verification failure: project_id=%d, github_setting_id=%d, err=%+v", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, deleteErr)
+			return nil, nil, deleteErr
+		}
 		return failedGitHubSetting, nil, nil
 	}
 	return verifiedGitHubSetting, gitHubAppRepositories, nil
@@ -479,7 +483,7 @@ func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyG
 		return nil, fmt.Errorf("installation_id is required: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
 
-	gitHubAppRepositories, err := c.repository.ListGitHubAppSettingRepository(ctx, req.ProjectId, req.GithubSettingId)
+	gitHubAppRepositories, err := c.repository.ListGitHubAppSettingRepositoryImmediately(ctx, req.ProjectId, req.GithubSettingId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -479,7 +479,11 @@ func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyG
 		return nil, fmt.Errorf("installation_id is required: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
 
-	protoGitHubSetting := convertGitHubSetting(githubSetting, nil, nil, nil, nil, false)
+	gitHubAppRepositories, err := c.repository.ListGitHubAppSettingRepository(ctx, req.ProjectId, req.GithubSettingId)
+	if err != nil {
+		return nil, err
+	}
+	protoGitHubSetting := convertGitHubSetting(githubSetting, gitHubAppRepositories, nil, nil, nil, false)
 	verifiedUser, err := c.githubClient.VerifyUserToServer(ctx, protoGitHubSetting, req.Code)
 	if err != nil {
 		c.logger.Warnf(ctx, "Failed to verify github app user: project_id=%d, github_setting_id=%d, err=%+v", req.ProjectId, req.GithubSettingId, err)
@@ -499,7 +503,7 @@ func (c *CodeService) VerifyGitHubAppUser(ctx context.Context, req *code.VerifyG
 	if err != nil {
 		return nil, err
 	}
-	return &code.VerifyGitHubAppUserResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, nil, nil, nil, nil, true)}, nil
+	return &code.VerifyGitHubAppUserResponse{GithubSetting: convertGitHubSetting(verifiedGitHubSetting, gitHubAppRepositories, nil, nil, nil, true)}, nil
 }
 
 func (c *CodeService) DeleteGitHubSetting(ctx context.Context, req *code.DeleteGitHubSettingRequest) (*empty.Empty, error) {

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -589,6 +589,9 @@ func TestPutGitHubSetting(t *testing.T) {
 					mockDB.On("CompleteGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.resolvedInstallationID, mock.Anything, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, repositories, c.mockUpdateError).Once()
 				} else {
 					mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
+					if c.mockUpdateError == nil {
+						mockDB.On("DeleteGitHubAppSettingRepository", mock.Anything, uint32(1)).Return(nil).Once()
+					}
 				}
 			}
 			got, err := svc.PutGitHubSetting(ctx, c.input)
@@ -1810,7 +1813,7 @@ func TestVerifyGitHubAppUser(t *testing.T) {
 				mockDB.On("GetGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockGitHubSetting, c.mockGetError).Once()
 			}
 			if c.mockGitHubAppRepositories != nil || c.mockGitHubAppRepositoryError != nil {
-				mockDB.On("ListGitHubAppSettingRepository", test.RepeatMockAnything(3)...).Return(c.mockGitHubAppRepositories, c.mockGitHubAppRepositoryError).Once()
+				mockDB.On("ListGitHubAppSettingRepositoryImmediately", test.RepeatMockAnything(3)...).Return(c.mockGitHubAppRepositories, c.mockGitHubAppRepositoryError).Once()
 			}
 			if c.wantStatus != "" {
 				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -1685,20 +1685,30 @@ func TestInvokeScan(t *testing.T) {
 func TestVerifyGitHubAppUser(t *testing.T) {
 	now := time.Now()
 	installationID := uint64(12345)
+	gitHubAppRepositories := &[]model.GitHubAppSettingRepository{{
+		CodeGitHubSettingID:      1,
+		GitHubRepositoryID:       67890,
+		GitHubRepositoryFullName: "owner/repo",
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}}
 	cases := []struct {
-		name               string
-		input              *code.VerifyGitHubAppUserRequest
-		githubClientError  error
-		verifiedUser       string
-		mockGitHubSetting  *model.CodeGitHubSetting
-		mockGetError       error
-		mockUpdateResponse *model.CodeGitHubSetting
-		mockUpdateError    error
-		want               *code.VerifyGitHubAppUserResponse
-		wantErr            bool
-		wantErrMsg         string
-		wantStatus         string
-		wantVerifiedUser   string
+		name                         string
+		input                        *code.VerifyGitHubAppUserRequest
+		githubClientError            error
+		verifiedUser                 string
+		mockGitHubSetting            *model.CodeGitHubSetting
+		mockGetError                 error
+		mockGitHubAppRepositories    *[]model.GitHubAppSettingRepository
+		mockGitHubAppRepositoryError error
+		mockUpdateResponse           *model.CodeGitHubSetting
+		mockUpdateError              error
+		want                         *code.VerifyGitHubAppUserResponse
+		wantErr                      bool
+		wantErrMsg                   string
+		wantStatus                   string
+		wantVerifiedUser             string
+		wantConfigRepositoryFullName string
 	}{
 		{
 			name:         "OK",
@@ -1710,10 +1720,19 @@ func TestVerifyGitHubAppUser(t *testing.T) {
 			mockUpdateResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGitHubUser: "octocat", VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
-			wantStatus:       code.GitHubVerificationStatusSuccess,
-			wantVerifiedUser: "octocat",
+			mockGitHubAppRepositories:    gitHubAppRepositories,
+			wantStatus:                   code.GitHubVerificationStatusSuccess,
+			wantVerifiedUser:             "octocat",
+			wantConfigRepositoryFullName: "owner/repo",
 			want: &code.VerifyGitHubAppUserResponse{GithubSetting: &code.GitHubSetting{
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGithubUser: "octocat", VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+				GithubAppSettingRepository: []*code.GitHubAppSettingRepository{{
+					GithubSettingId:          1,
+					GithubRepositoryId:       67890,
+					GithubRepositoryFullName: "owner/repo",
+					CreatedAt:                now.Unix(),
+					UpdatedAt:                now.Unix(),
+				}},
 			}},
 		},
 		{
@@ -1750,9 +1769,10 @@ func TestVerifyGitHubAppUser(t *testing.T) {
 			mockUpdateResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, ProjectID: 1, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusFailed, VerifiedGitHubUser: "previous-user", VerifiedAt: now,
 			},
-			wantStatus: code.GitHubVerificationStatusFailed,
-			wantErr:    true,
-			wantErrMsg: "github app user verification failed",
+			mockGitHubAppRepositories: gitHubAppRepositories,
+			wantStatus:                code.GitHubVerificationStatusFailed,
+			wantErr:                   true,
+			wantErrMsg:                "github app user verification failed",
 		},
 		{
 			name:  "NG user verification failed before resolving authenticated user",
@@ -1764,18 +1784,33 @@ func TestVerifyGitHubAppUser(t *testing.T) {
 			mockUpdateResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, ProjectID: 1, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusFailed, VerifiedGitHubUser: "previous-user", VerifiedAt: now,
 			},
-			wantStatus: code.GitHubVerificationStatusFailed,
-			wantErr:    true,
-			wantErrMsg: "github app user verification failed",
+			mockGitHubAppRepositories: gitHubAppRepositories,
+			wantStatus:                code.GitHubVerificationStatusFailed,
+			wantErr:                   true,
+			wantErrMsg:                "github app user verification failed",
+		},
+		{
+			name:  "NG list github app repositories failed",
+			input: &code.VerifyGitHubAppUserRequest{ProjectId: 1, GithubSettingId: 1, Code: "oauth-code"},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 1, ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp,
+			},
+			mockGitHubAppRepositoryError: errors.New("db error"),
+			wantErr:                      true,
+			wantErrMsg:                   "db error",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			mockDB := mocks.NewCodeRepoInterface(t)
-			svc := CodeService{repository: mockDB, githubClient: &FakeGithubClient{err: c.githubClientError, verifiedUser: c.verifiedUser}, logger: logging.NewLogger()}
+			fakeGithubClient := &FakeGithubClient{err: c.githubClientError, verifiedUser: c.verifiedUser}
+			svc := CodeService{repository: mockDB, githubClient: fakeGithubClient, logger: logging.NewLogger()}
 
 			if c.mockGitHubSetting != nil || c.mockGetError != nil {
 				mockDB.On("GetGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockGitHubSetting, c.mockGetError).Once()
+			}
+			if c.mockGitHubAppRepositories != nil || c.mockGitHubAppRepositoryError != nil {
+				mockDB.On("ListGitHubAppSettingRepository", test.RepeatMockAnything(3)...).Return(c.mockGitHubAppRepositories, c.mockGitHubAppRepositoryError).Once()
 			}
 			if c.wantStatus != "" {
 				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(1), c.wantStatus, c.wantVerifiedUser, mock.AnythingOfType("time.Time")).Return(c.mockUpdateResponse, c.mockUpdateError).Once()
@@ -1792,6 +1827,14 @@ func TestVerifyGitHubAppUser(t *testing.T) {
 			}
 			if !reflect.DeepEqual(c.want, got) {
 				t.Fatalf("Unexpected mapping: want=%+v, got=%+v", c.want, got)
+			}
+			if c.wantConfigRepositoryFullName != "" {
+				if fakeGithubClient.gotConfig == nil || len(fakeGithubClient.gotConfig.GithubAppSettingRepository) != 1 {
+					t.Fatalf("Expected github app repositories in config: %+v", fakeGithubClient.gotConfig)
+				}
+				if fakeGithubClient.gotConfig.GithubAppSettingRepository[0].GithubRepositoryFullName != c.wantConfigRepositoryFullName {
+					t.Fatalf("Unexpected repository full name: want=%s, got=%s", c.wantConfigRepositoryFullName, fakeGithubClient.gotConfig.GithubAppSettingRepository[0].GithubRepositoryFullName)
+				}
 			}
 		})
 	}
@@ -2542,6 +2585,7 @@ func (g *FakeGithubClient) VerifyInstallation(ctx context.Context, config *code.
 }
 
 func (g *FakeGithubClient) VerifyUserToServer(ctx context.Context, config *code.GitHubSetting, oauthCode string) (string, error) {
+	g.gotConfig = config
 	return g.verifiedUser, g.err
 }
 


### PR DESCRIPTION
## PRの概要

GitHub App設定では、Server-to-Server検証でinstallation_idを解決し、そのinstallationで許可されているRepository一覧をRISKEN側へ同期します。一方でUser-to-Server検証では、設定者本人が対象Repositoryを管理できるかを確認する必要がありますが、これまでselected repositoriesの場合に検証中のGitHub API呼び出しでRepository一覧を再取得していました。

このPRでは、User-to-Server検証において同期済みのRepository一覧を使うようにし、Repository一覧の解決・同期はServer-to-Server側、設定者本人の権限確認はUser-to-Server側という責務分離に寄せています。
これにより、検証対象Repositoryの基準がDB上の同期済み状態に揃い、検証成功時のレスポンスにも同期済みRepository一覧を含めます。

また、User-to-Server検証で使うRepository一覧はMasterDBから読み取るようにしています。GitHub App設定保存や再同期の直後にOAuth検証が続く場合でも、レプリケーション遅延で空または古いRepository一覧を見て検証することを避けるためです。GitHub App設定保存後の自動検証に失敗した場合は、古い`ghapp_setting_repository`を削除し、FAILED状態の設定に過去のRepository一覧が残らないようにしています。

```mermaid
flowchart TD
  A["VerifyGitHubAppUser"] --> B["GitHub設定を取得"]
  B --> C["同期済みRepository一覧をMasterDBから取得"]
  C --> D["OAuth codeでGitHub userを取得"]
  D --> E["installation_idとtarget resourceを確認"]
  E --> F{"repository_selection"}
  F -->|"all"| G["Org admin / User本人を確認"]
  F -->|"selected"| H["同期済みRepositoryごとにadmin権限を確認"]
```

| 条件 | 変更前 | 変更後 |
|---|---|---|
| selected repositories | User-to-Server検証中にGitHub APIからRepository一覧を再取得 | DBに同期済みのRepository一覧を使用 |
| User-to-Server検証時のRepository一覧読み取り | 通常の一覧取得と同じSlaveDB参照 | 検証用にMasterDB参照 |
| 同期済みRepositoryが空 | GitHub APIの取得結果次第で判定 | `github app repository is required` として検証失敗 |
| GitHub App自動検証失敗時 | FAILED更新後も古いRepository一覧が残る可能性がある | FAILED更新後に古いRepository一覧を削除 |
| 検証成功レスポンス | Repository一覧を含めない | 同期済みRepository一覧を含める |

### Other Options

| 方式 | メリット | デメリット | 今回の判断 |
|---|---|---|---|
| GitHub APIから都度Repository一覧を取得する | GitHub側で許可Repositoryが変更された直後でも、RISKEN側の再同期を待たずに最新の許可範囲を検証対象にできる | User-to-Server検証の中でRepository一覧の解決まで行うため、Server-to-Server検証・同期との責務が重なる。画面/APIで見える同期済みRepository一覧と、検証時にGitHub APIから取得したRepository一覧が一時的にずれる可能性がある。検証のたびにGitHub API呼び出しも増える | 採用しない |
| DBに同期済みのRepository一覧を使う | Repository一覧の解決・同期をServer-to-Server側に集約できる。User-to-Server側は、同期済みRepositoryに対する設定者本人の権限確認に集中できる。画面/APIで見えるRepository一覧と検証対象を揃えやすい | GitHub側で許可Repositoryを変更した後、RISKEN側で再同期するまではDB上のRepository一覧が古い可能性がある | 採用 |

GitHub側の許可範囲変更は再同期導線でRISKEN側へ反映する前提とし、このPRでは検証対象の一貫性と責務分離を優先しています。

## レビュー観点例

- [ ] Server-to-Server同期済みRepository一覧をUser-to-Server検証の正とする責務分離が妥当である点
- [ ] User-to-Server検証時のみMasterDBからRepository一覧を読むことで、保存/再同期直後の一貫性を優先している点
- [ ] GitHub App自動検証失敗時に古いRepository一覧を削除し、FAILED状態の表示を空に寄せる点
- [ ] DB上のRepository一覧が古い場合は再同期導線で回復する前提になる点
- [ ] selected repositoriesでRepositoryごとの権限確認を行うため、Repository数に応じてGitHub API呼び出し数が増える点
