### PR TITLE
GitHub App設定の環境変数名を明示する

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,16 +62,16 @@ type AppConf struct {
 	// datasource
 	GoogleCredentialPath         string   `required:"true" split_words:"true" default:"/tmp/credential.json"` // google
 	CodeDataKey                  string   `split_words:"true" required:"true"`                                // code
-	GithubAppID                  string   `split_words:"true"`                                                // code
-	GithubAppPrivateKey          string   `split_words:"true"`                                                // code
-	GithubAppAllowedBaseURLHosts []string `split_words:"true"`                                                // code
-	GithubAppOAuthClientID       string   `split_words:"true"`                                                // code
-	GithubAppOAuthClientSecret   string   `split_words:"true"`                                                // code
-	GithubAppOAuthBaseURL        string   `split_words:"true"`                                                // code
-	GithubAppAPIBaseURL          string   `split_words:"true"`                                                // code
-	GithubAppOAuthRedirectURL    string   `split_words:"true"`                                                // code
-	GithubAppOAuthScopes         []string `split_words:"true"`                                                // code
-	GithubAppOAuthAllowedHosts   []string `split_words:"true"`                                                // code
+	GithubAppID                  string   `envconfig:"GITHUB_APP_ID"`                                         // code
+	GithubAppPrivateKey          string   `envconfig:"GITHUB_APP_PRIVATE_KEY"`                                // code
+	GithubAppAllowedBaseURLHosts []string `envconfig:"GITHUB_APP_ALLOWED_BASE_URL_HOSTS"`                     // code
+	GithubAppOAuthClientID       string   `envconfig:"GITHUB_APP_OAUTH_CLIENT_ID"`                            // code
+	GithubAppOAuthClientSecret   string   `envconfig:"GITHUB_APP_OAUTH_CLIENT_SECRET"`                        // code
+	GithubAppOAuthBaseURL        string   `envconfig:"GITHUB_APP_OAUTH_BASE_URL"`                             // code
+	GithubAppAPIBaseURL          string   `envconfig:"GITHUB_APP_API_BASE_URL"`                               // code
+	GithubAppOAuthRedirectURL    string   `envconfig:"GITHUB_APP_OAUTH_REDIRECT_URL"`                         // code
+	GithubAppOAuthScopes         []string `envconfig:"GITHUB_APP_OAUTH_SCOPES"`                               // code
+	GithubAppOAuthAllowedHosts   []string `envconfig:"GITHUB_APP_OAUTH_ALLOWED_HOSTS"`                        // code
 	SlackAPIToken                string   `split_words:"true"`                                                // slack
 	AzureClientID                string   `split_words:"true"`                                                // azure
 	AzureTenantID                string   `split_words:"true"`                                                // azure


### PR DESCRIPTION
## PRの概要

GitHub App の OAuth 設定値について、envconfig の split_words が OAuth を O_AUTH と分割しないよう、環境変数名を envconfig タグで明示します。

フィールド名を Oauth に変える案もありますが、OAuth は Go の一般的な initialism 表記として大文字のまま扱う方が自然です。そのため、Go の命名は OAuth のまま維持し、運用上の環境変数名だけ GITHUB_APP_OAUTH_* として明示します。

## レビュー観点例

- [ ] Go のフィールド名は OAuth のまま維持し、環境変数名だけ envconfig タグで固定している点
- [ ] 既存の暫定的な GITHUB_APP_O_AUTH_* ではなく、正式な GITHUB_APP_OAUTH_* を利用する点
