### PR TITLE
GitHub Appのinstallation検証ステータスを分離

### DIFF
--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -383,8 +383,8 @@ func (c *Client) CompleteGitHubAppVerification(ctx context.Context, projectID, g
 	err := c.MasterDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		result := tx.Exec(updateGitHubAppInstallationVerification,
 			installationID,
-			code.GitHubVerificationStatusSuccess,
-			code.GitHubVerificationStatusSuccess,
+			code.GitHubVerificationStatusInstallationVerified,
+			code.GitHubVerificationStatusInstallationVerified,
 			code.GitHubVerificationStatusSuccess,
 			convertZeroValueToNull(verifiedGitHubUser),
 			verifiedAt,

--- a/pkg/db/code.go
+++ b/pkg/db/code.go
@@ -383,8 +383,8 @@ func (c *Client) CompleteGitHubAppVerification(ctx context.Context, projectID, g
 	err := c.MasterDB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		result := tx.Exec(updateGitHubAppInstallationVerification,
 			installationID,
-			code.GitHubVerificationStatusInstallationVerified,
-			code.GitHubVerificationStatusInstallationVerified,
+			code.GitHubVerificationStatusPendingUserVerification,
+			code.GitHubVerificationStatusPendingUserVerification,
 			code.GitHubVerificationStatusSuccess,
 			convertZeroValueToNull(verifiedGitHubUser),
 			verifiedAt,

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -441,8 +441,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 		ProjectID:           1,
 		InstallationID:      &installationID,
 		AuthMode:            code.GitHubAuthModeGitHubApp,
-		VerificationStatus:  code.GitHubVerificationStatusSuccess,
-		VerifiedGitHubUser:  "octocat",
+		VerificationStatus:  code.GitHubVerificationStatusInstallationVerified,
 		VerifiedAt:          now,
 	}
 	wantRepositories := &[]model.GitHubAppSettingRepository{
@@ -471,7 +470,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 			mockClosure: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
-					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WithArgs(installationID, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectExec(regexp.QuoteMeta(deleteGitHubAppSettingRepository)).
 					WithArgs(uint32(1)).
@@ -482,7 +481,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "project_id", "installation_id", "auth_mode", "verification_status", "verified_github_user", "verified_at"}).
-						AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusSuccess, "octocat", now))
+						AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusInstallationVerified, "", now))
 				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository+" and repo.code_github_setting_id = ?")).
 					WithArgs(uint32(1), uint32(1)).
 					WillReturnRows(sqlmock.NewRows([]string{
@@ -514,7 +513,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 			mockClosure: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
-					WithArgs(installationID, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WithArgs(installationID, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
 					WillReturnResult(sqlmock.NewResult(1, 0))
 				mock.ExpectRollback()
 			},

--- a/pkg/db/code_test.go
+++ b/pkg/db/code_test.go
@@ -441,7 +441,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 		ProjectID:           1,
 		InstallationID:      &installationID,
 		AuthMode:            code.GitHubAuthModeGitHubApp,
-		VerificationStatus:  code.GitHubVerificationStatusInstallationVerified,
+		VerificationStatus:  code.GitHubVerificationStatusPendingUserVerification,
 		VerifiedAt:          now,
 	}
 	wantRepositories := &[]model.GitHubAppSettingRepository{
@@ -470,7 +470,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 			mockClosure: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
-					WithArgs(installationID, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WithArgs(installationID, code.GitHubVerificationStatusPendingUserVerification, code.GitHubVerificationStatusPendingUserVerification, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectExec(regexp.QuoteMeta(deleteGitHubAppSettingRepository)).
 					WithArgs(uint32(1)).
@@ -481,7 +481,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `code_github_setting` WHERE project_id = ? AND code_github_setting_id = ?")).
 					WillReturnRows(sqlmock.NewRows([]string{
 						"code_github_setting_id", "project_id", "installation_id", "auth_mode", "verification_status", "verified_github_user", "verified_at"}).
-						AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusInstallationVerified, "", now))
+						AddRow(uint32(1), uint32(1), installationID, code.GitHubAuthModeGitHubApp, code.GitHubVerificationStatusPendingUserVerification, "", now))
 				mock.ExpectQuery(regexp.QuoteMeta(selectListGitHubAppSettingRepository+" and repo.code_github_setting_id = ?")).
 					WithArgs(uint32(1), uint32(1)).
 					WillReturnRows(sqlmock.NewRows([]string{
@@ -513,7 +513,7 @@ func TestCompleteGitHubAppVerification(t *testing.T) {
 			mockClosure: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(updateGitHubAppInstallationVerification)).
-					WithArgs(installationID, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusInstallationVerified, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
+					WithArgs(installationID, code.GitHubVerificationStatusPendingUserVerification, code.GitHubVerificationStatusPendingUserVerification, code.GitHubVerificationStatusSuccess, "octocat", now, uint32(1), uint32(1), code.GitHubAuthModeGitHubApp).
 					WillReturnResult(sqlmock.NewResult(1, 0))
 				mock.ExpectRollback()
 			},

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -419,7 +419,7 @@ func (c *CodeService) completeGitHubAppInstallationVerification(ctx context.Cont
 	if err != nil {
 		return nil, nil, err
 	}
-	return c.repository.CompleteGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, installationID, repositoriesForUpsert, githubSetting.GitHubUser, time.Now())
+	return c.repository.CompleteGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, installationID, repositoriesForUpsert, "", time.Now())
 }
 
 func buildGitHubAppSettingRepositoryForUpsert(githubSettingID uint32, repositories []*ghub.Repository) ([]*code.GitHubAppSettingRepositoryForUpsert, error) {

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -500,16 +500,16 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: "SUCCESS", VerifiedGitHubUser: "octocat", VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
+			wantStatus:             code.GitHubVerificationStatusPendingUserVerification,
 		},
 		{
 			name: "OK github app without installation id",
@@ -517,16 +517,16 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
+			wantStatus:             code.GitHubVerificationStatusPendingUserVerification,
 		},
 		{
 			name: "OK github app verification failed",
@@ -581,7 +581,7 @@ func TestPutGitHubSetting(t *testing.T) {
 				mockDB.On("UpsertGitHubSetting", test.RepeatMockAnything(2)...).Return(c.mockResponse, c.mockError).Once()
 			}
 			if c.wantStatus != "" {
-				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusInstallationVerified {
+				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusPendingUserVerification {
 					repositories := c.mockRepositoryResponse
 					if repositories == nil {
 						repositories = &[]model.GitHubAppSettingRepository{}
@@ -634,12 +634,12 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
+			wantStatus:             code.GitHubVerificationStatusPendingUserVerification,
 			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
 			}},
 		},
 		{
@@ -649,12 +649,12 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
+			wantStatus:             code.GitHubVerificationStatusPendingUserVerification,
 			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusPendingUserVerification, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
 			}},
 		},
 		{
@@ -695,7 +695,7 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				mockDB.On("GetGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockGitHubSetting, c.mockGetError).Once()
 			}
 			if c.wantStatus != "" {
-				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusInstallationVerified {
+				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusPendingUserVerification {
 					repositories := c.mockRepositoryResponse
 					if repositories == nil {
 						repositories = &[]model.GitHubAppSettingRepository{}

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -500,16 +500,16 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "SUCCESS", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: "SUCCESS", VerifiedGitHubUser: "octocat", VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusSuccess,
+			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
 		},
 		{
 			name: "OK github app without installation id",
@@ -517,16 +517,16 @@ func TestPutGitHubSetting(t *testing.T) {
 				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp},
 			},
 			want: &code.PutGitHubSettingResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: "SUCCESS", VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix()},
 			},
 			mockResponse: &model.CodeGitHubSetting{
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: verifiedAt, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusSuccess,
+			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
 		},
 		{
 			name: "OK github app verification failed",
@@ -581,7 +581,7 @@ func TestPutGitHubSetting(t *testing.T) {
 				mockDB.On("UpsertGitHubSetting", test.RepeatMockAnything(2)...).Return(c.mockResponse, c.mockError).Once()
 			}
 			if c.wantStatus != "" {
-				if c.wantStatus == code.GitHubVerificationStatusSuccess {
+				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusInstallationVerified {
 					repositories := c.mockRepositoryResponse
 					if repositories == nil {
 						repositories = &[]model.GitHubAppSettingRepository{}
@@ -634,13 +634,12 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGitHubUser: "octocat", VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusSuccess,
-			wantVerifiedUser:       "octocat",
+			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
 			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGithubUser: "octocat", VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
 			}},
 		},
 		{
@@ -650,13 +649,12 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, CreatedAt: now, UpdatedAt: now,
 			},
 			mockUpdateResponse: &model.CodeGitHubSetting{
-				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGitHubUser: "octocat", VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
+				CodeGitHubSettingID: 1, Name: "one", ProjectID: 1, Type: "ORGANIZATION", TargetResource: "target", GitHubUser: "octocat", InstallationID: &installationID, AuthMode: code.GitHubAuthModeGitHubApp, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now, CreatedAt: now, UpdatedAt: now,
 			},
 			resolvedInstallationID: installationID,
-			wantStatus:             code.GitHubVerificationStatusSuccess,
-			wantVerifiedUser:       "octocat",
+			wantStatus:             code.GitHubVerificationStatusInstallationVerified,
 			want: &code.VerifyGitHubAppInstallationResponse{GithubSetting: &code.GitHubSetting{
-				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusSuccess, VerifiedGithubUser: "octocat", VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
+				GithubSettingId: 1, Name: "one", ProjectId: 1, Type: code.Type_ORGANIZATION, TargetResource: "target", GithubUser: "octocat", AuthMode: code.GitHubAuthModeGitHubApp, InstallationId: installationID, VerificationStatus: code.GitHubVerificationStatusInstallationVerified, VerifiedAt: now.Unix(), CreatedAt: now.Unix(), UpdatedAt: now.Unix(),
 			}},
 		},
 		{
@@ -697,7 +695,7 @@ func TestVerifyGitHubAppInstallation(t *testing.T) {
 				mockDB.On("GetGitHubSetting", test.RepeatMockAnything(3)...).Return(c.mockGitHubSetting, c.mockGetError).Once()
 			}
 			if c.wantStatus != "" {
-				if c.wantStatus == code.GitHubVerificationStatusSuccess {
+				if c.wantStatus == code.GitHubVerificationStatusSuccess || c.wantStatus == code.GitHubVerificationStatusInstallationVerified {
 					repositories := c.mockRepositoryResponse
 					if repositories == nil {
 						repositories = &[]model.GitHubAppSettingRepository{}

--- a/proto/code/validator.go
+++ b/proto/code/validator.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	GitHubAuthModePersonalAccessToken            = "PERSONAL_ACCESS_TOKEN"
-	GitHubAuthModeGitHubApp                      = "GITHUB_APP"
-	GitHubVerificationStatusInstallationVerified = "INSTALLATION_VERIFIED"
-	GitHubVerificationStatusSuccess              = "SUCCESS"
-	GitHubVerificationStatusFailed               = "FAILED"
+	GitHubAuthModePersonalAccessToken               = "PERSONAL_ACCESS_TOKEN"
+	GitHubAuthModeGitHubApp                         = "GITHUB_APP"
+	GitHubVerificationStatusPendingUserVerification = "PENDING_USER_VERIFICATION"
+	GitHubVerificationStatusSuccess                 = "SUCCESS"
+	GitHubVerificationStatusFailed                  = "FAILED"
 )
 
 // validateRepositoryName validates repository name format (owner/repo)

--- a/proto/code/validator.go
+++ b/proto/code/validator.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	GitHubAuthModePersonalAccessToken = "PERSONAL_ACCESS_TOKEN"
-	GitHubAuthModeGitHubApp           = "GITHUB_APP"
-	GitHubVerificationStatusSuccess   = "SUCCESS"
-	GitHubVerificationStatusFailed    = "FAILED"
+	GitHubAuthModePersonalAccessToken            = "PERSONAL_ACCESS_TOKEN"
+	GitHubAuthModeGitHubApp                      = "GITHUB_APP"
+	GitHubVerificationStatusInstallationVerified = "INSTALLATION_VERIFIED"
+	GitHubVerificationStatusSuccess              = "SUCCESS"
+	GitHubVerificationStatusFailed               = "FAILED"
 )
 
 // validateRepositoryName validates repository name format (owner/repo)


### PR DESCRIPTION
## PRの概要

GitHub App設定の保存時に実行されるinstallation検証の成功ステータスを、最終成功を表す`SUCCESS`からユーザー確認待ちを表す`PENDING_USER_VERIFICATION`へ変更します。

これにより、GitHub Appが対象Repositoryへアクセスできることの確認と、設定者本人がGitHub側で対象Repositoryを扱えることの確認をステータス上で分離します。

## 背景

E2Eテストで、GitHub App設定を保存しただけで`SUCCESS`になり、User-to-ServerのGitHubユーザー確認まで完了したように見えてしまうことが分かりました。

保存時点で完了しているのはServer-to-Serverによるinstallation検証とRepository同期であり、設定者本人のGitHubユーザー確認は別ステップとして残るため、状態を分けて表現する必要があります。

本来は、GitHub App側の接続確認が完了しただけでは設定完了扱いにせず、設定者本人のGitHubユーザー確認が完了するまで「GitHubユーザー確認待ち」として扱うのが理想です。

<img width="1471" height="1322" alt="スクリーンショット 2026-07-02 16 03 48" src="https://github.com/user-attachments/assets/9e267d5e-1379-4139-b57b-12933380a73b" />


## 修正点

| 変更点 | 内容 |
|---|---|
| ステータス追加 | `PENDING_USER_VERIFICATION`を追加し、GitHubユーザー確認待ちの中間状態を表現できるようにしました。 |
| 保存時の状態変更 | GitHub App設定保存時や再同期時のServer-to-Server検証成功では、`SUCCESS`ではなく`PENDING_USER_VERIFICATION`を保存するようにしました。 |
| GitHubユーザー情報 | installation検証では`verified_github_user`を更新せず、User-to-Server確認が成功した場合のみ保存するようにしました。 |
| テスト更新 | 保存時・再同期時の期待ステータスを`PENDING_USER_VERIFICATION`に変更しました。 |

```mermaid
flowchart TD
    A["RISKEN設定者<br/>GitHub App設定を保存する"] --> B["RISKEN<br/>GitHub Appのinstallationを検証する"]
    B --> C["RISKEN<br/>Repository一覧を同期する"]

    C --> Old["変更前<br/>verification_status = SUCCESS"]
    Old --> OldRisk["User-to-Server未実施でも<br/>検証完了に見えてしまう"]

    C --> New["変更後<br/>verification_status = PENDING_USER_VERIFICATION"]
    New --> D["RISKEN設定者<br/>GitHubユーザー確認を実行する"]
    D --> E["RISKEN<br/>User-to-Serverで設定者の権限を確認する"]
    E --> F["確認成功後<br/>verification_status = SUCCESS"]

    Old:::problem
    OldRisk:::problem
    New:::current
    D:::current
    E:::current
    F:::success

    classDef problem fill:#ffe7e7,stroke:#dc3545,stroke-width:2px,color:#24292f;
    classDef current fill:#fff3cd,stroke:#d39e00,stroke-width:2px,color:#24292f;
    classDef success fill:#e6f4ea,stroke:#198754,stroke-width:2px,color:#24292f;
```

## 重点レビューポイント

- `PENDING_USER_VERIFICATION`を中間ステータスとして追加するだけの最小対応で、保存時のinstallation検証とUser-to-Server確認を適切に分離できているか。
- 既存の`SUCCESS`判定に依存している処理へ意図しない影響が出ないか。

## 動作確認

Webからバックエンドまで含めたE2Eテストで、GitHub App設定保存時に`SUCCESS`へ進んでしまう挙動を確認しました。

このPRではその挙動を修正し、保存時は`PENDING_USER_VERIFICATION`、GitHubユーザー確認成功後は`SUCCESS`になるようにしています。
