### PR TITLE
GitHub App未インストール時の連携失敗状態を永続化

### DIFF
--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -407,6 +407,9 @@ func (c *CodeService) GetGitHubAppInstallationStatus(ctx context.Context, req *c
 		reason := code.GitHubAppInstallationReasonCheckFailed
 		if isGitHubAppInstallationNotFound(err) {
 			reason = code.GitHubAppInstallationReasonNotInstalled
+			if _, updateErr := c.repository.UpdateGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, code.GitHubVerificationStatusFailed, "", time.Now()); updateErr != nil {
+				return nil, updateErr
+			}
 		}
 		c.logger.Warnf(ctx, "Failed to get github app installation status: project_id=%d, github_setting_id=%d, target_resource=%q, reason=%s", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, githubSetting.TargetResource, reason)
 		return &code.GetGitHubAppInstallationStatusResponse{

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -414,6 +414,9 @@ func (c *CodeService) GetGitHubAppInstallationStatus(ctx context.Context, req *c
 			if _, updateErr := c.repository.UpdateGitHubAppVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, code.GitHubVerificationStatusFailed, "", time.Now()); updateErr != nil {
 				return nil, updateErr
 			}
+			if deleteErr := c.repository.DeleteGitHubAppSettingRepository(ctx, githubSetting.CodeGitHubSettingID); deleteErr != nil {
+				return nil, deleteErr
+			}
 		}
 		c.logger.Warnf(ctx, "Failed to get github app installation status: project_id=%d, github_setting_id=%d, target_resource=%q, reason=%s", githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, githubSetting.TargetResource, reason)
 		return &code.GetGitHubAppInstallationStatusResponse{

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -395,6 +395,9 @@ func (c *CodeService) GetGitHubAppInstallationStatus(ctx context.Context, req *c
 	if err != nil {
 		return nil, err
 	}
+	if githubSetting.AuthMode != code.GitHubAuthModeGitHubApp {
+		return nil, fmt.Errorf("github setting is not github app auth mode: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
+	}
 	status, err := c.githubClient.GetGitHubAppInstallationStatus(ctx, &code.GitHubSetting{
 		ProjectId:       githubSetting.ProjectID,
 		GithubSettingId: githubSetting.CodeGitHubSettingID,

--- a/pkg/server/code/code.go
+++ b/pkg/server/code/code.go
@@ -398,14 +398,15 @@ func (c *CodeService) GetGitHubAppInstallationStatus(ctx context.Context, req *c
 	if githubSetting.AuthMode != code.GitHubAuthModeGitHubApp {
 		return nil, fmt.Errorf("github setting is not github app auth mode: project_id=%d, github_setting_id=%d", req.ProjectId, req.GithubSettingId)
 	}
-	status, err := c.githubClient.GetGitHubAppInstallationStatus(ctx, &code.GitHubSetting{
+	config := &code.GitHubSetting{
 		ProjectId:       githubSetting.ProjectID,
 		GithubSettingId: githubSetting.CodeGitHubSettingID,
 		Type:            getType(githubSetting.Type),
 		BaseUrl:         githubSetting.BaseURL,
 		TargetResource:  githubSetting.TargetResource,
 		AuthMode:        code.GitHubAuthModeGitHubApp,
-	})
+	}
+	status, err := c.githubClient.GetGitHubAppInstallationStatus(ctx, config)
 	if err != nil {
 		reason := code.GitHubAppInstallationReasonCheckFailed
 		if isGitHubAppInstallationNotFound(err) {
@@ -422,6 +423,11 @@ func (c *CodeService) GetGitHubAppInstallationStatus(ctx context.Context, req *c
 				Reason:         reason,
 			},
 		}, nil
+	}
+	if githubSetting.VerificationStatus == code.GitHubVerificationStatusFailed {
+		if _, err := c.repository.UpdateGitHubAppInstallationVerification(ctx, githubSetting.ProjectID, githubSetting.CodeGitHubSettingID, config.InstallationId, code.GitHubVerificationStatusPendingUserVerification, "", time.Now()); err != nil {
+			return nil, err
+		}
 	}
 	status.Reason = code.GitHubAppInstallationReasonInstalled
 	return &code.GetGitHubAppInstallationStatusResponse{GithubAppInstallationStatus: status}, nil

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -738,6 +738,8 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 		clientErr         error
 		mockUpdateError   error
 		wantStatus        string
+		installationID    uint64
+		wantInstallStatus string
 		want              *code.GetGitHubAppInstallationStatusResponse
 		wantConfig        *code.GitHubSetting
 		wantErr           bool
@@ -776,6 +778,37 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				BaseUrl:         "https://api.github.com/",
 				TargetResource:  "target",
 				AuthMode:        code.GitHubAuthModeGitHubApp,
+			},
+		},
+		{
+			name: "OK installed after verification failure",
+			input: &code.GetGitHubAppInstallationStatusRequest{
+				ProjectId:       1,
+				GithubSettingId: 10,
+			},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 10,
+				ProjectID:           1,
+				Type:                code.Type_ORGANIZATION.String(),
+				BaseURL:             "https://api.github.com/",
+				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+				VerificationStatus:  code.GitHubVerificationStatusFailed,
+			},
+			clientStatus: &code.GitHubAppInstallationStatus{
+				TargetResource:      "target",
+				Installed:           true,
+				RepositorySelection: "selected",
+			},
+			installationID:    123,
+			wantInstallStatus: code.GitHubVerificationStatusPendingUserVerification,
+			want: &code.GetGitHubAppInstallationStatusResponse{
+				GithubAppInstallationStatus: &code.GitHubAppInstallationStatus{
+					TargetResource:      "target",
+					Installed:           true,
+					RepositorySelection: "selected",
+					Reason:              code.GitHubAppInstallationReasonInstalled,
+				},
 			},
 		},
 		{
@@ -904,7 +937,10 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 			if c.wantStatus != "" {
 				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(10), c.wantStatus, "", mock.AnythingOfType("time.Time")).Return(c.mockGitHubSetting, c.mockUpdateError).Once()
 			}
-			fakeGitHubClient := &FakeGithubClient{err: c.clientErr, installationStatus: c.clientStatus}
+			if c.wantInstallStatus != "" {
+				mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(10), c.installationID, c.wantInstallStatus, "", mock.AnythingOfType("time.Time")).Return(c.mockGitHubSetting, c.mockUpdateError).Once()
+			}
+			fakeGitHubClient := &FakeGithubClient{err: c.clientErr, installationID: c.installationID, installationStatus: c.clientStatus}
 			svc := CodeService{repository: mockDB, githubClient: fakeGitHubClient, logger: logging.NewLogger()}
 			got, err := svc.GetGitHubAppInstallationStatus(context.Background(), c.input)
 			if !c.wantErr && err != nil {
@@ -2787,6 +2823,7 @@ func (g *FakeGithubClient) VerifyInstallation(ctx context.Context, config *code.
 
 func (g *FakeGithubClient) GetGitHubAppInstallationStatus(ctx context.Context, config *code.GitHubSetting) (*code.GitHubAppInstallationStatus, error) {
 	g.gotConfig = config
+	config.InstallationId = g.installationID
 	return g.installationStatus, g.err
 }
 

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -737,7 +737,9 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 		clientStatus      *code.GitHubAppInstallationStatus
 		clientErr         error
 		mockUpdateError   error
+		mockDeleteError   error
 		wantStatus        string
+		wantDelete        bool
 		installationID    uint64
 		wantInstallStatus string
 		want              *code.GetGitHubAppInstallationStatusResponse
@@ -841,6 +843,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 			},
 			clientErr:  fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
 			wantStatus: code.GitHubVerificationStatusFailed,
+			wantDelete: true,
 			want: &code.GetGitHubAppInstallationStatusResponse{
 				GithubAppInstallationStatus: &code.GitHubAppInstallationStatus{
 					TargetResource: "target",
@@ -866,6 +869,26 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 			clientErr:       fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
 			mockUpdateError: errors.New("db error"),
 			wantStatus:      code.GitHubVerificationStatusFailed,
+			wantErr:         true,
+		},
+		{
+			name: "NG delete repositories after not installed",
+			input: &code.GetGitHubAppInstallationStatusRequest{
+				ProjectId:       1,
+				GithubSettingId: 10,
+			},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 10,
+				ProjectID:           1,
+				Type:                code.Type_ORGANIZATION.String(),
+				BaseURL:             "https://api.github.com/",
+				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
+			},
+			clientErr:       fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
+			mockDeleteError: errors.New("db error"),
+			wantStatus:      code.GitHubVerificationStatusFailed,
+			wantDelete:      true,
 			wantErr:         true,
 		},
 		{
@@ -936,6 +959,9 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 			}
 			if c.wantStatus != "" {
 				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(10), c.wantStatus, "", mock.AnythingOfType("time.Time")).Return(c.mockGitHubSetting, c.mockUpdateError).Once()
+			}
+			if c.wantDelete {
+				mockDB.On("DeleteGitHubAppSettingRepository", mock.Anything, uint32(10)).Return(c.mockDeleteError).Once()
 			}
 			if c.wantInstallStatus != "" {
 				mockDB.On("UpdateGitHubAppInstallationVerification", mock.Anything, uint32(1), uint32(10), c.installationID, c.wantInstallStatus, "", mock.AnythingOfType("time.Time")).Return(c.mockGitHubSetting, c.mockUpdateError).Once()

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -754,6 +754,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				Type:                code.Type_ORGANIZATION.String(),
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
 			},
 			clientStatus: &code.GitHubAppInstallationStatus{
 				TargetResource:      "target",
@@ -803,6 +804,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				Type:                code.Type_ORGANIZATION.String(),
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
 			},
 			clientErr:  fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
 			wantStatus: code.GitHubVerificationStatusFailed,
@@ -826,6 +828,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				Type:                code.Type_ORGANIZATION.String(),
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
 			},
 			clientErr:       fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
 			mockUpdateError: errors.New("db error"),
@@ -844,6 +847,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				Type:                code.Type_ORGANIZATION.String(),
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
 			},
 			clientErr: fmt.Errorf("list github app repositories: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
 			want: &code.GetGitHubAppInstallationStatusResponse{
@@ -866,6 +870,7 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				Type:                code.Type_ORGANIZATION.String(),
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
+				AuthMode:            code.GitHubAuthModeGitHubApp,
 			},
 			clientErr: errors.New("github api failed"),
 			want: &code.GetGitHubAppInstallationStatusResponse{
@@ -875,6 +880,19 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 					Reason:         code.GitHubAppInstallationReasonCheckFailed,
 				},
 			},
+		},
+		{
+			name: "NG personal access token auth mode",
+			input: &code.GetGitHubAppInstallationStatusRequest{
+				ProjectId:       1,
+				GithubSettingId: 10,
+			},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 10,
+				ProjectID:           1,
+				AuthMode:            code.GitHubAuthModePersonalAccessToken,
+			},
+			wantErr: true,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/server/code/code_test.go
+++ b/pkg/server/code/code_test.go
@@ -736,6 +736,8 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 		mockGetError      error
 		clientStatus      *code.GitHubAppInstallationStatus
 		clientErr         error
+		mockUpdateError   error
+		wantStatus        string
 		want              *code.GetGitHubAppInstallationStatusResponse
 		wantConfig        *code.GitHubSetting
 		wantErr           bool
@@ -802,7 +804,8 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 				BaseURL:             "https://api.github.com/",
 				TargetResource:      "target",
 			},
-			clientErr: fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
+			clientErr:  fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
+			wantStatus: code.GitHubVerificationStatusFailed,
 			want: &code.GetGitHubAppInstallationStatusResponse{
 				GithubAppInstallationStatus: &code.GitHubAppInstallationStatus{
 					TargetResource: "target",
@@ -810,6 +813,24 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 					Reason:         code.GitHubAppInstallationReasonNotInstalled,
 				},
 			},
+		},
+		{
+			name: "NG persist not installed status",
+			input: &code.GetGitHubAppInstallationStatusRequest{
+				ProjectId:       1,
+				GithubSettingId: 10,
+			},
+			mockGitHubSetting: &model.CodeGitHubSetting{
+				CodeGitHubSettingID: 10,
+				ProjectID:           1,
+				Type:                code.Type_ORGANIZATION.String(),
+				BaseURL:             "https://api.github.com/",
+				TargetResource:      "target",
+			},
+			clientErr:       fmt.Errorf("find installation: %w", &ghub.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
+			mockUpdateError: errors.New("db error"),
+			wantStatus:      code.GitHubVerificationStatusFailed,
+			wantErr:         true,
 		},
 		{
 			name: "OK repository check not found is check failed",
@@ -861,6 +882,9 @@ func TestGetGitHubAppInstallationStatus(t *testing.T) {
 			mockDB := mocks.NewCodeRepoInterface(t)
 			if c.input.GetProjectId() != 0 && c.input.GetGithubSettingId() != 0 {
 				mockDB.On("GetGitHubSetting", context.Background(), c.input.GetProjectId(), c.input.GetGithubSettingId()).Return(c.mockGitHubSetting, c.mockGetError).Once()
+			}
+			if c.wantStatus != "" {
+				mockDB.On("UpdateGitHubAppVerification", mock.Anything, uint32(1), uint32(10), c.wantStatus, "", mock.AnythingOfType("time.Time")).Return(c.mockGitHubSetting, c.mockUpdateError).Once()
 			}
 			fakeGitHubClient := &FakeGithubClient{err: c.clientErr, installationStatus: c.clientStatus}
 			svc := CodeService{repository: mockDB, githubClient: fakeGitHubClient, logger: logging.NewLogger()}
@@ -1744,7 +1768,7 @@ func TestInvokeScan(t *testing.T) {
 		mockGetGitHubSettingResponse *model.CodeGitHubSetting
 		mockGetGitHubSettingError    error
 		mockGithubClient             *FakeGithubClient
-		mockRefreshGitleaksError       error
+		mockRefreshGitleaksError     error
 		wantErr                      bool
 	}{
 		{
@@ -2128,7 +2152,7 @@ func TestInvokeScanDependency(t *testing.T) {
 		mockGetGitHubSettingResponse *model.CodeGitHubSetting
 		mockGetGitHubSettingError    error
 		mockGithubClient             *FakeGithubClient
-		mockRefreshDependencyError    error
+		mockRefreshDependencyError   error
 		wantErr                      bool
 	}{
 		{


### PR DESCRIPTION
## PRの概要

GitHub App連携成功後にAppがアンインストールされても、一覧画面では連携成功の表示が残り続ける問題を解消します。

インストール状態確認APIがGitHubから未インストールを検出した際、対象のGitHub設定の検証状態を連携失敗としてデータベースへ保存します。

これにより、詳細画面で未インストールを確認した後に一覧を再取得した場合も、セッション内の一時的な表示上書きに依存せず連携失敗状態を表示できます。

| 状態 | 変更前 | 変更後 |
|---|---|---|
| GitHub Appのアンインストールを検出 | API応答のみ未インストール | API応答に加えて検証状態を連携失敗として保存 |
| 一覧画面の再取得 | 連携成功が残る場合がある | 保存済みの連携失敗状態を表示 |

## レビュー観点例

- [ ] GitHub APIの404だけを未インストールとして永続化する点
- [ ] 状態更新に失敗した場合に未インストール応答を返さずエラーとする点
- [ ] インストール状態確認APIが状態更新も担う責務分離の点
- [ ] 既存の連携失敗状態とアンインストール検出による失敗状態を同じ値で扱う点